### PR TITLE
Add namespace_resource_usage table design for fair sharing

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -76,7 +76,79 @@ CREATE TABLE job_events (
 );
 ```
 
-## 4. 状態遷移
+## 4. `namespace_resource_usage` テーブル
+
+namespace ごとの累計リソース消費量を記録する。Dispatcher の fair sharing（dispatch 優先度の調整）に使用する。
+
+`jobs` テーブルとは独立しており、`cjob reset` による jobs レコード削除の影響を受けない。
+
+```sql
+CREATE TABLE namespace_resource_usage (
+    namespace              TEXT PRIMARY KEY,
+    cpu_millicores_seconds BIGINT NOT NULL DEFAULT 0,
+    memory_mib_seconds     BIGINT NOT NULL DEFAULT 0,
+    gpu_seconds            BIGINT NOT NULL DEFAULT 0,
+    period_start           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### 4.1 カラム説明
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `namespace` | TEXT PK | ユーザーの namespace |
+| `cpu_millicores_seconds` | BIGINT | `time_limit_seconds × cpu（ミリコア換算）` の累計。"2" → 2000, "0.5" → 500 |
+| `memory_mib_seconds` | BIGINT | `time_limit_seconds × memory（MiB 換算）` の累計。"4Gi" → 4096, "500Mi" → 500 |
+| `gpu_seconds` | BIGINT | `time_limit_seconds × gpu（個数）` の累計 |
+| `period_start` | TIMESTAMPTZ | 現在の集計期間の開始時刻 |
+| `updated_at` | TIMESTAMPTZ | 最終更新時刻 |
+
+### 4.2 加算処理
+
+Watcher がジョブを RUNNING に遷移させる際に、`started_at` の記録と同じトランザクション内で累計消費量を加算する。
+
+加算量の計算: `time_limit_seconds × リソース量`（方式 C: 予約のみ、返却なし）。ジョブが `time_limit_seconds` より早く完了しても返却しない。これにより、ユーザーが `time_limit_seconds` を適切に見積もるインセンティブが生まれ、隙間充填（gap filling）の推定精度も向上する。
+
+CANCELLED に対する特別処理は不要。RUNNING 前のキャンセルは加算されておらず、RUNNING 中のキャンセルは既に加算済みで返却しない。
+
+```sql
+INSERT INTO namespace_resource_usage (namespace, cpu_millicores_seconds, memory_mib_seconds, gpu_seconds, period_start, updated_at)
+VALUES (:namespace, :delta_cpu, :delta_mem, :delta_gpu, NOW(), NOW())
+ON CONFLICT (namespace) DO UPDATE SET
+    cpu_millicores_seconds = namespace_resource_usage.cpu_millicores_seconds + EXCLUDED.cpu_millicores_seconds,
+    memory_mib_seconds     = namespace_resource_usage.memory_mib_seconds + EXCLUDED.memory_mib_seconds,
+    gpu_seconds            = namespace_resource_usage.gpu_seconds + EXCLUDED.gpu_seconds,
+    updated_at = NOW();
+```
+
+アトミックな UPSERT により、初回は INSERT（`period_start = NOW()`）、以降は加算のみ（`period_start` は変更しない）。
+
+### 4.3 期間リセット
+
+Dispatcher が累計消費量を参照する際に `period_start` を確認し、集計期間を超過していたらリセットする。
+
+```sql
+UPDATE namespace_resource_usage
+SET cpu_millicores_seconds = 0,
+    memory_mib_seconds = 0,
+    gpu_seconds = 0,
+    period_start = NOW(),
+    updated_at = NOW()
+WHERE NOW() - period_start > MAKE_INTERVAL(secs => :reset_interval_seconds);
+```
+
+リセット期間は `FAIR_SHARE_RESET_INTERVAL_SEC`（デフォルト 604800 秒 = 7 日）で設定する。
+
+### 4.4 設計判断
+
+- **jobs テーブルと独立**: FK を持たないため、`cjob reset` の `DELETE FROM jobs` に影響されない
+- **namespace 単位で集約**: ジョブごとの明細は不要。方式 C（予約のみ）により RUNNING 遷移時に確定加算するため、後から個別ジョブの寄与を差し引く必要がない
+- **リソース種別ごとにカラムを分離**: CPU・メモリ・GPU の消費パターンが異なるため、Dispatcher が重み付けを柔軟に設定できるよう分離する
+- **BIGINT の十分性**: `time_limit_seconds`（最大 604800）× `cpu_millicores`（最大 300000）でも 1 回あたり最大約 1.8 × 10^11。BIGINT（最大 9.2 × 10^18）で十分
+- **期間ベースのリセット**: 外部 CronJob ではなく Dispatcher が参照時にリセットする方式を採用。コンポーネントを増やさずシンプルに実現できる
+
+## 5. 状態遷移
 
 ```text
 QUEUED

--- a/docs/architecture/kueue.md
+++ b/docs/architecture/kueue.md
@@ -138,6 +138,14 @@ ResourceQuota と ClusterQueue nominalQuota の違い：ResourceQuota は User P
 
 隙間充填の詳細は [dispatcher.md](dispatcher.md) §2.4 を参照。
 
+### Fair sharing に関する設定
+
+| 設定 | 設定箇所 | 値 | 管理主体 | 適用単位 | 説明 |
+|---|---|---|---|---|---|
+| `FAIR_SHARE_RESET_INTERVAL_SEC` | ConfigMap | 604800 (7日) | Dispatcher | 全体 | 累計リソース消費量のリセット間隔（秒）。Dispatcher が参照時に `period_start` からの経過がこの値を超えていたらリセットする |
+
+累計リソース消費量の詳細は [database.md](database.md) §4 を参照。
+
 ### 実行時間に関する制限
 
 | 制限 | 設定箇所 | 値 | 管理主体 | 適用単位 | 制限対象 |


### PR DESCRIPTION
## Summary

- namespace ごとの累計リソース消費量を記録する `namespace_resource_usage` テーブルの設計を `database.md` に追加
- RUNNING 遷移時に `time_limit_seconds × リソース量` で加算（方式 C: 予約のみ、返却なし）
- 一定期間（デフォルト 7 日、ConfigMap で設定可能）で累積消費量をリセットする期間ベース方式
- `FAIR_SHARE_RESET_INTERVAL_SEC` 設定を `kueue.md` のリソース制限まとめに追加

## Test plan

- [ ] `database.md` §4 のテーブル定義・加算 SQL・リセット SQL が正しいことを確認
- [ ] `kueue.md` の Fair sharing 設定値が `database.md` と整合していることを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)