### PR TITLE
Add cluster set-quota/show-quota commands

### DIFF
--- a/ctl/src/cmd/cluster.rs
+++ b/ctl/src/cmd/cluster.rs
@@ -215,6 +215,7 @@ pub async fn set_quota(
     cpu: u32,
     memory: &str,
     gpu: Option<u32>,
+    force: bool,
 ) -> Result<()> {
     // Validate memory format
     validate_memory_format(memory)?;
@@ -225,10 +226,13 @@ pub async fn set_quota(
     let alloc_mem_mib = totals.memory_mib;
     let alloc_gpu = totals.gpus;
 
+    let mut exceeds = false;
+
     // Validate CPU
     if (cpu as i64) > alloc_cpu_cores {
+        exceeds = true;
         eprintln!(
-            "Warning: CPU {} exceeds cluster allocatable total ({} cores)",
+            "Error: CPU {} exceeds cluster allocatable total ({} cores)",
             cpu, alloc_cpu_cores,
         );
     } else if (cpu as i64) < alloc_cpu_cores / 10 {
@@ -241,8 +245,9 @@ pub async fn set_quota(
     // Validate memory
     if let Some(mem_mib) = memory_to_mib(memory) {
         if (mem_mib as i64) > alloc_mem_mib {
+            exceeds = true;
             eprintln!(
-                "Warning: Memory {} exceeds cluster allocatable total ({:.1} GiB)",
+                "Error: Memory {} exceeds cluster allocatable total ({:.1} GiB)",
                 memory,
                 alloc_mem_mib as f64 / 1024.0,
             );
@@ -258,8 +263,9 @@ pub async fn set_quota(
     // Validate GPU
     if let Some(g) = gpu {
         if (g as i64) > alloc_gpu {
+            exceeds = true;
             eprintln!(
-                "Warning: GPU {} exceeds cluster allocatable total ({})",
+                "Error: GPU {} exceeds cluster allocatable total ({})",
                 g, alloc_gpu,
             );
         } else if alloc_gpu > 0 && (g as i64) < alloc_gpu / 10 {
@@ -268,6 +274,10 @@ pub async fn set_quota(
                 g, alloc_gpu,
             );
         }
+    }
+
+    if exceeds && !force {
+        bail!("Specified values exceed cluster allocatable totals. Use --force to override.");
     }
 
     // Fetch current ClusterQueue

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -151,6 +151,9 @@ enum ClusterCommands {
         /// GPU count (e.g. 4)
         #[arg(long)]
         gpu: Option<u32>,
+        /// Allow values exceeding cluster allocatable total
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -238,11 +241,11 @@ async fn main() -> Result<()> {
                     let k8s_client = k8s::client().await?;
                     cmd::cluster::show_quota(&k8s_client).await
                 }
-                ClusterCommands::SetQuota { cpu, memory, gpu } => {
+                ClusterCommands::SetQuota { cpu, memory, gpu, force } => {
                     let conn =
                         db::connect(&config.database, config.system_namespace()).await?;
                     let k8s_client = k8s::client().await?;
-                    cmd::cluster::set_quota(&conn.client, &k8s_client, cpu, &memory, gpu)
+                    cmd::cluster::set_quota(&conn.client, &k8s_client, cpu, &memory, gpu, force)
                         .await
                 }
             }


### PR DESCRIPTION
## Summary

- `cjobctl cluster show-quota`: K8s API 経由で ClusterQueue の現在の nominalQuota（CPU/Memory/GPU）を表示
- `cjobctl cluster set-quota --cpu <N> --memory <SIZE> [--gpu <N>]`: `node_resources` テーブルの合計値と比較してバリデーション（警告）を行い、確認プロンプト後に ClusterQueue の `nominalQuota` を更新
- GPU quota の追加・更新・削除に対応（`--gpu 0` で削除）
- Kueue CRD は `k8s-openapi` に含まれないため `DynamicObject` で操作

Closes #20

## Test plan

- [x] `cargo build` が通ること（確認済み）
- [x] `cjobctl cluster show-quota` で現在の quota が表示されること
- [x] `cjobctl cluster set-quota --cpu 256 --memory 1000Gi` でバリデーション・確認後に更新されること
- [x] `cjobctl cluster set-quota --cpu 256 --memory 1000Gi --gpu 4` で GPU quota が追加されること
- [x] `cjobctl cluster set-quota --cpu 256 --memory 1000Gi --gpu 0` で GPU quota が削除されること
- [x] allocatable 合計を超える値を指定した場合に警告が表示されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)