### PR TITLE
Remove CLI_BINARY_DIR from ConfigMap and Deployment (#41)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -170,7 +170,6 @@ data:
   USER_NAMESPACE_LABEL: cjob.io/user-namespace=true
   WORKSPACE_MOUNT_PATH: /home/jovyan
   LOG_BASE_DIR: /home/jovyan/.cjob/logs
-  CLI_BINARY_DIR: /cli-binary
   JOB_NODE_TAINT: "role=computing:NoSchedule"
 ```
 
@@ -716,11 +715,6 @@ spec:
                 configMapKeyRef:
                   name: cjob-config
                   key: MAX_TIME_LIMIT_SECONDS
-            - name: CLI_BINARY_DIR
-              valueFrom:
-                configMapKeyRef:
-                  name: cjob-config
-                  key: CLI_BINARY_DIR
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/configmap-cjob-config.yaml
+++ b/k8s/base/configmap-cjob-config.yaml
@@ -27,5 +27,4 @@ data:
   USER_NAMESPACE_LABEL: cjob.io/user-namespace=true
   WORKSPACE_MOUNT_PATH: /home/jovyan
   LOG_BASE_DIR: /home/jovyan/.cjob/logs
-  CLI_BINARY_DIR: /cli-binary
   JOB_NODE_TAINT: "role=computing:NoSchedule"

--- a/k8s/base/submit-api/deployment.yaml
+++ b/k8s/base/submit-api/deployment.yaml
@@ -65,11 +65,6 @@ spec:
                 configMapKeyRef:
                   name: cjob-config
                   key: MAX_TIME_LIMIT_SECONDS
-            - name: CLI_BINARY_DIR
-              valueFrom:
-                configMapKeyRef:
-                  name: cjob-config
-                  key: CLI_BINARY_DIR
           resources:
             requests:
               cpu: "100m"


### PR DESCRIPTION
## Summary

- Remove `CLI_BINARY_DIR` from `cjob-config` ConfigMap (`k8s/base/configmap-cjob-config.yaml`)
- Remove `CLI_BINARY_DIR` env var injection from submit-api Deployment (`k8s/base/submit-api/deployment.yaml`)
- Remove corresponding entries from deployment docs (`docs/deployment.md`)
- `config.py` default value (`"/cli-binary"`) is retained as the single source of truth

Closes #41

## Test plan

- [x] Verify `CLI_BINARY_DIR` is no longer in ConfigMap manifest
- [x] Verify submit-api Deployment no longer references `CLI_BINARY_DIR` from ConfigMap
- [x] Verify submit-api still uses the default value from `config.py` (no behavioral change)
- [x] Verify CLI binary download endpoint (`/cli/version`, `/cli/download`) works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)