### PR TITLE
Fix design-implementation discrepancies (#84)

### DIFF
--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -14,11 +14,7 @@ pub fn print_job_table(jobs: &[JobSummary]) {
         let job_type = if job.completions.is_some() { "sweep" } else { "job" };
         let progress = match (job.completions, job.succeeded_count, job.failed_count) {
             (Some(total), Some(succ), Some(fail)) => {
-                if fail > 0 {
-                    format!("{}/{}/{}", succ, fail, total)
-                } else {
-                    format!("{}/{}", succ, total)
-                }
+                format!("{}/{}/{}", succ, fail, total)
             }
             _ => "-".to_string(),
         };
@@ -82,6 +78,8 @@ pub fn print_job_detail(job: &JobDetailResponse) {
     println!("job_id:        {}", job.job_id);
     if is_sweep {
         println!("type:          sweep");
+    } else {
+        println!("type:          job");
     }
     println!("status:        {}", job.status);
     println!("command:       {}", job.command);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -507,7 +507,8 @@ async fn cmd_reset(client: &client::CjobClient) -> Result<()> {
         .collect();
     if !active.is_empty() {
         println!("完了していないジョブがあるためリセットできません。");
-        println!("完了待ちのジョブ: {:?}", active);
+        let active_str: Vec<String> = active.iter().map(|id| id.to_string()).collect();
+        println!("完了待ちのジョブ: {}", active_str.join(", "));
         return Ok(());
     }
 

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -169,7 +169,7 @@ cjob add --time-limit 1d -- python main.py       # 1日
 cjob add --time-limit 3d -- python main.py       # 3日
 ```
 
-受け付ける表記: 整数（秒）、`<数値>s`（秒）、`<数値>h`（時間）、`<数値>d`（日）。最大 7 日。
+受け付ける表記: 整数（秒）、`<数値>s`（秒）、`<数値>m`（分）、`<数値>h`（時間）、`<数値>d`（日）。最大 7 日。
 
 ## 5. `cjob logs` の動作
 

--- a/server/src/cjob/api/routes.py
+++ b/server/src/cjob/api/routes.py
@@ -12,6 +12,7 @@ from .auth import UserInfo, get_namespace, get_user_info
 from .schemas import (
     CancelRequest,
     CancelResponse,
+    SingleCancelResponse,
     CliVersionResponse,
     CliVersionsResponse,
     DeleteRequest,
@@ -139,7 +140,7 @@ def get_job_detail(
     return result
 
 
-@router.post("/jobs/{job_id}/cancel")
+@router.post("/jobs/{job_id}/cancel", response_model=SingleCancelResponse)
 def post_cancel_single(
     job_id: int,
     namespace: str = Depends(get_namespace),
@@ -148,9 +149,7 @@ def post_cancel_single(
     result = cancel_single(session, namespace, job_id)
     if result.get("not_found"):
         raise HTTPException(status_code=404, detail="Job not found")
-    if result.get("skipped"):
-        return {"job_id": job_id, "status": result["status"]}
-    return result
+    return SingleCancelResponse(job_id=job_id, status=result["status"])
 
 
 @router.post("/jobs/cancel", response_model=CancelResponse)

--- a/server/src/cjob/api/schemas.py
+++ b/server/src/cjob/api/schemas.py
@@ -79,6 +79,11 @@ class JobDetailResponse(BaseModel):
     failed_indexes: str | None = None
 
 
+class SingleCancelResponse(BaseModel):
+    job_id: int
+    status: str
+
+
 class CancelRequest(BaseModel):
     job_ids: list[int]
 


### PR DESCRIPTION
## Summary
- Add `SingleCancelResponse` schema and `response_model` for `POST /v1/jobs/{job_id}/cancel` endpoint
- Show `type: job` for normal jobs in `cjob status` output (previously only sweep jobs showed type)
- Always display 3-part progress format (`succeeded/failed/total`) in `cjob list` for sweep jobs
- Format active job IDs as comma-separated in `cjob reset` output (was `[3, 7, 12]`, now `3, 7, 12`)
- Document `m` (minutes) suffix for `--time-limit` option in cli.md

## Test plan
- [x] Python tests pass (209 passed)
- [x] Rust CLI tests pass (38 passed)
- [x] `cjob status <job-id>` shows `type: job` for normal jobs
- [x] `cjob list` shows `0/0/100` format for sweep jobs with no failures
- [x] `cjob reset` with active jobs shows IDs without brackets

## Post-apply actions
- Submit API の再デプロイ（`SingleCancelResponse` スキーマ追加による OpenAPI ドキュメント更新の反映）
- CLI バイナリの再ビルドと配布（`cjob status` / `cjob list` / `cjob reset` の表示修正の反映）

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)