### PR TITLE
Fix parse_memory_mib to handle all Kubernetes memory suffixes

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,7 +37,7 @@ cargo test
 | `tests/test_reconciler.py` | `watcher/reconciler.py` | 45 | reconcile_cycle のステータス同期（started_at / finished_at / last_error / node_name 記録・RUNNING スキップ時の完了時取得・既存値の非上書き）/ CANCELLED 削除 / orphan 検出 / DELETING フェーズ 1・2 / namespace 分離 / RUNNING 遷移時の累計消費量加算（namespace_daily_usage）/ K8s Job 消失検出（DISPATCHED・RUNNING → FAILED 遷移・last_error・finished_at 設定）/ list_cjob_k8s_jobs の API エラー伝播・正常系 / parse_cpu_millicores / parse_memory_mib / Prometheus カウンター（SUCCEEDED / FAILED 遷移・K8s Job 消失で完了カウンター増加） |
 | `tests/test_scheduler.py` | `dispatcher/scheduler.py` 5関数 | 22 | cas_update_to_dispatching / mark_dispatched / mark_failed / reset_stale_dispatching の CAS 動作・状態遷移 / filter_by_resource_quota の ResourceQuota 残リソースによる dispatch 候補フィルタリング（quota 行なし通過・CPU / メモリ / GPU 不足スキップ・sweep parallelism 倍計算・サイクル内累計追跡・namespace 混在・空リスト） |
 | `tests/test_gap_filling.py` | `dispatcher/scheduler.py::apply_gap_filling` | 7 | 隙間充填フィルタリング。無効時 / 滞留なし / 残り時間による候補選択 / RUNNING なし / namespace 混在 / 残り時間 0 / 候補なし |
-| `tests/test_resource_utils.py` | `resource_utils.py` | 12 | CPU・メモリ文字列のパース。整数 / 小数 / ミリコア / Gi / Mi / Ki / 大きな値等 |
+| `tests/test_resource_utils.py` | `resource_utils.py` | 18 | CPU・メモリ文字列のパース。整数 / 小数 / ミリコア / Gi / Mi / Ki / Ti / milli-bytes / 10 進接頭辞(k, M, G, T) / 大きな値等 |
 | `tests/test_node_sync.py` | `watcher/node_sync.py::sync_node_resources` | 14 | ノードリソース同期。挿入 / 更新 / 削除 / 全削除 / GPU パース / API エラー時のデータ保持 / ラベルセレクタ / 部分失敗時の失敗 flavor データ保持 / 部分失敗時の成功 flavor 古ノード削除 |
 | `tests/test_quota_sync.py` | `watcher/quota_sync.py::sync_flavor_quotas` | 7 | flavor quota 同期。挿入 / 複数 flavor / 更新 / 削除 / API エラー時のデータ保持 / 空 resourceGroups / ClusterQueue 名設定 |
 | `tests/test_resource_quota_sync.py` | `watcher/resource_quota_sync.py::sync_resource_quotas` | 13 | ResourceQuota 同期。ユーザー namespace への挿入 / 値更新 / ユーザー namespace 除去時の行削除 / ResourceQuota なし時の行削除 / namespace 一覧 API エラー時のデータ保持 / ResourceQuota 一覧 API エラー時のデータ保持 / ユーザー namespace なしの全削除 / CPU・メモリパース / GPU リソース名取得 / field_selector 設定 / USER_NAMESPACE_LABEL 設定 / 非ユーザー namespace の除外 / ジョブなし namespace の追跡 |
@@ -52,7 +52,7 @@ cargo test
 | `src/cmd/cli_list.rs` | `parse_versions` / `sort_versions` | 9 | ls 出力パース（latest 除外 / 空入力 / パース不能エントリ）/ ソート（降順 / プレリリース優先 / 設計書出力例の再現） |
 | `src/cmd/cli_set_latest.rs` | `run`（バリデーション） | 2 | プレリリース版の拒否（beta / rc） |
 
-**合計: Python 285 + Rust (cli) 62 + Rust (cjobctl) 28 = 375 テスト**
+**合計: Python 291 + Rust (cli) 62 + Rust (cjobctl) 28 = 381 テスト**
 
 ### 未テスト
 

--- a/server/src/cjob/resource_utils.py
+++ b/server/src/cjob/resource_utils.py
@@ -9,12 +9,44 @@ def parse_cpu_millicores(cpu: str) -> int:
 
 
 def parse_memory_mib(memory: str) -> int:
-    """Convert memory string (e.g. "4Gi", "500Mi", "1024") to MiB."""
+    """Convert Kubernetes memory quantity string to MiB.
+
+    Supports all Kubernetes resource.Quantity suffixes:
+    - Binary: Ki, Mi, Gi, Ti, Pi, Ei
+    - Decimal: m (milli), k, M, G, T, P, E
+    - Plain integer (bytes)
+    """
+    MIB = 1024 * 1024  # bytes per MiB
+
+    # Binary suffixes (check 2-char suffixes first)
+    if memory.endswith("Ei"):
+        return int(math.ceil(float(memory[:-2]) * 1024**4))
+    if memory.endswith("Pi"):
+        return int(math.ceil(float(memory[:-2]) * 1024**3))
+    if memory.endswith("Ti"):
+        return int(math.ceil(float(memory[:-2]) * 1024**2))
     if memory.endswith("Gi"):
         return int(math.ceil(float(memory[:-2]) * 1024))
     if memory.endswith("Mi"):
         return int(math.ceil(float(memory[:-2])))
     if memory.endswith("Ki"):
         return int(math.ceil(float(memory[:-2]) / 1024))
+
+    # Decimal suffixes (single-char, check after 2-char)
+    if memory.endswith("E"):
+        return int(math.ceil(float(memory[:-1]) * 10**18 / MIB))
+    if memory.endswith("P"):
+        return int(math.ceil(float(memory[:-1]) * 10**15 / MIB))
+    if memory.endswith("T"):
+        return int(math.ceil(float(memory[:-1]) * 10**12 / MIB))
+    if memory.endswith("G"):
+        return int(math.ceil(float(memory[:-1]) * 10**9 / MIB))
+    if memory.endswith("M"):
+        return int(math.ceil(float(memory[:-1]) * 10**6 / MIB))
+    if memory.endswith("k"):
+        return int(math.ceil(float(memory[:-1]) * 10**3 / MIB))
+    if memory.endswith("m"):
+        return int(math.ceil(int(memory[:-1]) / 1000 / MIB))
+
     # Plain bytes
-    return int(math.ceil(int(memory) / (1024 * 1024)))
+    return int(math.ceil(int(memory) / MIB))

--- a/server/tests/test_resource_utils.py
+++ b/server/tests/test_resource_utils.py
@@ -39,3 +39,26 @@ class TestParseMemoryMib:
 
     def test_fractional_gi(self):
         assert parse_memory_mib("1.5Gi") == 1536
+
+    def test_ti_suffix(self):
+        assert parse_memory_mib("1Ti") == 1048576  # 1 TiB = 1024^2 MiB
+
+    def test_milli_bytes_suffix(self):
+        # 265428978892800m = 265428978892.8 bytes ≈ 253133 MiB
+        assert parse_memory_mib("265428978892800m") == 253133
+
+    def test_decimal_k_suffix(self):
+        # 1048576k = 1048576000 bytes ≈ 1000 MiB
+        assert parse_memory_mib("1048576k") == 1000
+
+    def test_decimal_M_suffix(self):
+        # 1000M = 10^9 bytes ≈ 954 MiB
+        assert parse_memory_mib("1000M") == 954
+
+    def test_decimal_G_suffix(self):
+        # 4G = 4 * 10^9 bytes ≈ 3815 MiB
+        assert parse_memory_mib("4G") == 3815
+
+    def test_decimal_T_suffix(self):
+        # 1T = 10^12 bytes ≈ 953674 MiB
+        assert parse_memory_mib("1T") == 953675


### PR DESCRIPTION
## Summary
- `parse_memory_mib()` に Kubernetes の全メモリサフィックスを追加（`m`, `k`, `M`, `G`, `T`, `P`, `E`, `Ti`, `Pi`, `Ei`）
- milli-bytes 表記（`m` サフィックス）未対応により `sync_resource_quotas()` が `ValueError` で失敗し、`cjob usage` の Used 値が実際の使用量を反映しなかった問題を修正
- 6 テストケースを追加（milli-bytes, Ti, k, M, G, T）

## Test plan
- [x] `cd server && uv run python -m pytest tests/test_resource_utils.py -v` で新規テスト含む全 18 テストが通過すること
- [x] `cd server && uv run python -m pytest tests/ -v` で全 301 テストが通過すること
- [x] Job Pod を複数起動した状態で `cjob usage` を実行し、Used のメモリ値が実際の使用量を反映していることを確認

## Post-apply actions
- Watcher の再デプロイが必要（`parse_memory_mib` は Watcher の `sync_resource_quotas()` から呼び出される）。CLI の更新だけでは反映されない
  ```bash
  kubectl rollout restart deployment/cjob-watcher -n cjob-system
  ```

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)