### PR TITLE
Fix cjobctl usage list Daily Usage duplicating dates per flavor

### DIFF
--- a/ctl/src/cmd/usage.rs
+++ b/ctl/src/cmd/usage.rs
@@ -110,11 +110,18 @@ async fn fetch_window_days(k8s_client: &kube::Client, system_ns: &str) -> i32 {
 
 pub async fn list(client: &Client, k8s_client: &kube::Client, system_ns: &str, namespace: Option<&str>) -> Result<()> {
     // 1. Daily raw data
+    // namespace_daily_usage の主キーは (namespace, usage_date, flavor) の複合キーで、
+    // 同じ (namespace, date) に対して flavor ごとに行が存在する。Daily Usage の
+    // 表示では flavor をまたいで集計するため、namespace と usage_date で GROUP BY する。
     let daily_rows = client
         .query(
-            "SELECT namespace, usage_date, cpu_millicores_seconds, memory_mib_seconds, gpu_seconds \
+            "SELECT namespace, usage_date, \
+                    SUM(cpu_millicores_seconds)::BIGINT AS cpu_millicores_seconds, \
+                    SUM(memory_mib_seconds)::BIGINT AS memory_mib_seconds, \
+                    SUM(gpu_seconds)::BIGINT AS gpu_seconds \
              FROM namespace_daily_usage \
              WHERE ($1::TEXT IS NULL OR namespace = $1) \
+             GROUP BY namespace, usage_date \
              ORDER BY usage_date ASC, namespace ASC",
             &[&namespace],
         )


### PR DESCRIPTION
## Summary
- `cjobctl usage list` の Daily Usage セクションで同じ日付が flavor の数だけ重複表示されていた問題を修正
- `namespace_daily_usage` は `(namespace, usage_date, flavor)` が複合主キーで、`(namespace, date)` ペアに対して flavor ごとに行が存在する。Daily Usage クエリに `GROUP BY namespace, usage_date` と `SUM()` を追加し、flavor をまたいで集計するようにした
- `cjob usage` API 側で以前に適用された同種の修正（e47e1c6）を cjobctl 側にも適用する形

## Test plan
- [x] `cargo check` でコンパイル確認
- [x] 実環境で `cjobctl usage list` を実行し、Daily Usage に各 `(namespace, date)` が 1 行ずつしか表示されないことを確認
- [x] 複数 flavor の消費量がある日付で、表示される CPU / Mem / GPU の値が flavor の合算値になっていることを確認
- [x] `cjobctl usage list --namespace <ns>` による絞り込みが引き続き動作することを確認

## Post-apply actions
- cjobctl の再ビルドと配布

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)