### PR TITLE
docs: document cjobctl usage list and cjob set in design docs

### DIFF
--- a/docs/architecture/cjobctl.md
+++ b/docs/architecture/cjobctl.md
@@ -113,13 +113,83 @@ namespace = "cjob-system"   # 省略時デフォルト
 
 `usage list` の Daily Usage はデフォルトで日付昇順（古い日付が上）で表示する。`--namespace` オプションで特定 namespace のデータのみに絞り込める（Daily / 7-Day Window / DRF すべてのセクションに適用）。
 
-`usage list` の DRF dominant share 計算は Dispatcher（`server/src/cjob/dispatcher/scheduler.py`）と同一の式を使用する:
+#### `cjobctl usage list`
+
+`namespace_daily_usage` テーブルから各 namespace のリソース消費量を読み出し、3 つのセクションを順に出力する。出力は常にこの順序で、データが存在しない場合は `No usage data found.` を表示して終了する。
+
+各セクションのカラム構成と単位換算:
+
+**Daily Usage**
+
+| カラム | 内容 |
+|---|---|
+| `NAMESPACE` | ユーザー namespace |
+| `DATE` | `usage_date`（YYYY-MM-DD） |
+| `CPU (core·h)` | `SUM(cpu_millicores_seconds) / 1000 / 3600` |
+| `Mem (GiB·h)` | `SUM(memory_mib_seconds) / 1024 / 3600` |
+| `GPU (h)` | `SUM(gpu_seconds) / 3600` |
+
+`namespace_daily_usage` の主キーは `(namespace, usage_date, flavor)` の複合キーで、同じ `(namespace, date)` に対して flavor ごとに行が存在する。Daily Usage では flavor をまたいで集計するため、`GROUP BY namespace, usage_date` で合算する（複数 flavor がある場合でも同一日付が 1 行に統合される）。並び順は `ORDER BY usage_date ASC, namespace ASC`。
+
+**N-Day Window Aggregate**
+
+| カラム | 内容 |
+|---|---|
+| `NAMESPACE` | ユーザー namespace |
+| `CPU (core·h)` | 過去 N 日間の合算（単位換算は Daily Usage と同じ） |
+| `Mem (GiB·h)` | 同上 |
+| `GPU (h)` | 同上 |
+
+集計ウィンドウ日数 N は `cjob-system` namespace の ConfigMap `cjob-config` のキー `FAIR_SHARE_WINDOW_DAYS` から取得する（取得失敗時・キー未設定時は 7 日）。セクションヘッダーには実際に使用した日数が `=== N-Day Window Aggregate ===` として反映される。SQL 条件は `usage_date > CURRENT_DATE - N`。
+
+**DRF Dominant Share**
+
+| カラム | 内容 |
+|---|---|
+| `NAMESPACE` | ユーザー namespace |
+| `CPU (core·h)` | 過去 N 日間の flavor 合算（Window Aggregate と同等） |
+| `Mem (GiB·h)` | 同上 |
+| `GPU (h)` | 同上 |
+| `WEIGHT` | `namespace_weights.weight`（行が無い場合は 1.0） |
+| `DOM_SHARE` | weight で割った重み付き DRF スコア |
+
+計算式は Dispatcher（`server/src/cjob/dispatcher/scheduler.py`）と同一で、flavor 単位で `dominant_share = GREATEST(cpu_share, mem_share, gpu_share)` を算出し、`flavor_quotas.drf_weight` で重み付けして namespace 内で合算する:
 
 ```
-dominant_share = GREATEST(cpu_share, mem_share, gpu_share) / weight
+window_seconds        = N × 86400
+cpu_share(f)          = cpu_millicores_seconds(ns,f) / (cap_cpu(f) × window_seconds)
+mem_share(f)          = memory_mib_seconds(ns,f)     / (cap_mem(f) × window_seconds)
+gpu_share(f)          = gpu_seconds(ns,f)            / (cap_gpu(f) × window_seconds)
+dominant_share(ns,f)  = MAX(cpu_share, mem_share, gpu_share)
+drf_score(ns)         = Σ_f dominant_share(ns,f) × drf_weight(f)
+DOM_SHARE(ns)         = drf_score(ns) / namespace_weight(ns)
 ```
 
-クラスタのリソース総量は DB の `node_resources` テーブルから `SUM()` で取得する。テーブルが空の場合は dominant share 列を `N/A` と表示する（Dispatcher は DRF ソートを無効化して namespace 名順にフォールバックするが、cjobctl は表示ツールのため計算不能であることを明示する）。
+各 flavor の容量 `cap_*` は `node_resources` の allocatable 合計を `flavor_quotas` の nominalQuota で上限クランプした値（`min(allocatable, nominalQuota)`）を使用する。`node_resources` が空、または `flavor_quotas` に該当 flavor が無い場合は fallback として allocatable をそのまま用いる。`node_resources` 自体が空の場合は DRF セクション全体を `No node_resources data. DRF disabled.` に置き換える（Dispatcher は DRF ソートを無効化して namespace 名順にフォールバックするが、cjobctl は計算不能であることを明示する）。
+
+行の並び順は `DOM_SHARE` 昇順（=消費の少ない namespace が上）。`WEIGHT = 0` の namespace は `DOM_SHARE` を `inf` 相当として末尾に配置する。
+
+出力例（`FAIR_SHARE_WINDOW_DAYS=7`、cpu flavor のみの構成）:
+
+```
+=== Daily Usage ===
+NAMESPACE            DATE             CPU (core·h)    Mem (GiB·h)    GPU (h)
+user-alice           2026-04-05               12.0           48.0        0.0
+user-bob             2026-04-05                4.0           16.0        0.0
+user-alice           2026-04-06                8.0           32.0        0.0
+
+=== 7-Day Window Aggregate ===
+NAMESPACE              CPU (core·h)    Mem (GiB·h)    GPU (h)
+user-alice                     20.0           80.0        0.0
+user-bob                        4.0           16.0        0.0
+
+=== DRF Dominant Share ===
+NAMESPACE              CPU (core·h)    Mem (GiB·h)    GPU (h)   WEIGHT        DOM_SHARE
+user-bob                        4.0           16.0        0.0        1         0.001488
+user-alice                     20.0           80.0        0.0        1         0.007440
+```
+
+複数 flavor がある構成では、Daily Usage セクションは `(namespace, date)` 単位で 1 行に統合され、flavor ごとの内訳は表示されない（flavor 別の内訳が必要な場合は `cjob usage` を利用する）。DRF Dominant Share は flavor 単位で dominant share を計算し、`drf_weight` で重み付け合算する。
 
 #### `cjobctl usage quota`
 

--- a/docs/architecture/cjobctl.md
+++ b/docs/architecture/cjobctl.md
@@ -189,7 +189,7 @@ user-bob                        4.0           16.0        0.0        1         0
 user-alice                     20.0           80.0        0.0        1         0.007440
 ```
 
-複数 flavor がある構成では、Daily Usage セクションは `(namespace, date)` 単位で 1 行に統合され、flavor ごとの内訳は表示されない（flavor 別の内訳が必要な場合は `cjob usage` を利用する）。DRF Dominant Share は flavor 単位で dominant share を計算し、`drf_weight` で重み付け合算する。
+複数 flavor がある構成では、Daily Usage セクションは `(namespace, date)` 単位で 1 行に統合され、flavor ごとの内訳は表示されない。flavor 別の内訳を閲覧する CLI コマンドは現時点では存在せず、必要な場合は `namespace_daily_usage` を直接参照する必要がある。DRF Dominant Share は内部で flavor 単位に dominant share を計算し、`drf_weight` で重み付け合算するが、出力には flavor 列を含めず namespace 単位の集計値のみを表示する。
 
 #### `cjobctl usage quota`
 

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -674,7 +674,71 @@ cjob release 1,3,5
 cjob release --all
 ```
 
-## 13. `cjob reset` の動作
+## 13. `cjob set` の動作
+
+QUEUED または HELD 状態のジョブについて、Dispatcher に渡すリソース要求・flavor・time limit を事後的に上書きする。1 つ以上のフィールドが指定されていない場合はエラーで終了する。
+
+job_id の指定形式は `cjob cancel` と同じく単体・範囲・複数組み合わせに対応する。単体指定時は `POST /v1/jobs/{job_id}/set`、複数指定時は `POST /v1/jobs/set` を呼ぶ。
+
+### 変更可能なフィールド
+
+| オプション | 型 | 内容 |
+|---|---|---|
+| `--cpu <cpu>` | 文字列 | CPU 要求量（例: `4`, `2000m`） |
+| `--memory <memory>` | 文字列 | メモリ要求量（例: `16Gi`, `16384Mi`） |
+| `--gpu <N>` | 整数 | GPU 個数 |
+| `--flavor <name>` | 文字列 | ResourceFlavor 名 |
+| `--time-limit <duration>` | 文字列 | 実行時間上限（例: `12h`, `30m`）。API には秒に換算して送る |
+
+指定されなかったフィールドは元の値を保持する。値のパース（`parse_duration` など）は `cjob add` と同じユーティリティを共用する。
+
+### 対象ジョブの条件
+
+API 側で以下の状態チェックを行う。
+
+- `QUEUED` / `HELD` 以外の状態のジョブは `skipped` に分類される（RUNNING / DISPATCHING / DISPATCHED / SUCCEEDED / FAILED / CANCELLED / DELETING など、すでに K8s に引き渡されたまたは完了済みのジョブは変更不可）。
+- 存在しない job_id は `not_found` に分類される。
+
+### 動作
+
+```
+# ※ CLI の実装は Rust で行う。以下は概念説明のための擬似コードである。
+
+fn cmd_set(expr, cpu, memory, gpu, flavor, time_limit):
+    if すべてのパラメータが None:
+        エラー終了: "specify at least one parameter to modify (--cpu, --memory, --gpu, --flavor, --time-limit)"
+
+    time_limit_seconds = time_limit を秒に変換（指定時のみ）
+
+    job_ids = parse_job_ids(expr)   // cancel と同じパース処理を共用
+    if len(job_ids) == 1:
+        POST /v1/jobs/{job_id}/set にパラメータを送る
+        "Job {job_id}: {status}" を表示する
+    else:
+        POST /v1/jobs/set に job_ids とパラメータを送る
+        result を受け取り:
+            modified があれば "Modified: [job_ids]" を表示する
+            skipped があれば "Skipped (not QUEUED / HELD): [job_ids]" を表示する
+            not_found があれば "Not found: [job_ids]" を表示する
+```
+
+### 使用例
+
+```bash
+# 単体指定で flavor のみ変更
+cjob set 5 --flavor cpu-sub
+
+# 複数指定でリソース要求と time limit をまとめて変更
+cjob set 10,11,12 --cpu 4 --memory 16Gi --time-limit 12h
+
+# 範囲 + 個別指定
+cjob set 10-20,25,30 --cpu 8
+
+# cjob list からの ID 注入（QUEUED のまま flavor を切り替える）
+cjob set $(cjob list --status QUEUED --flavor cpu --format ids) --flavor cpu-sub
+```
+
+## 14. `cjob reset` の動作
 
 1. `GET /v1/jobs` でジョブ一覧を取得し、レスポンスの `log_base_dir` を保持した上で以下の順で確認する
    - `DELETING` のジョブが1件でも存在する場合は「前回のリセット処理がまだ完了していません。しばらく待ってから再試行してください。」を表示して中止する
@@ -700,7 +764,7 @@ $ cjob reset   # 全ジョブ完了後
 リセットを開始しました。バックグラウンドでクリーンアップが完了するまでお待ちください。
 ```
 
-## 14. `cjob usage` の動作
+## 15. `cjob usage` の動作
 
 `GET /v1/usage` を呼び出し、直近 `FAIR_SHARE_WINDOW_DAYS` 日分の日別リソース使用状況を表示する。
 
@@ -768,7 +832,7 @@ Resource Usage (past 7 days)
   Total                    44.5           89.0
 ```
 
-## 15. `cjob update` の動作
+## 16. `cjob update` の動作
 
 CLI バイナリのバージョン管理と更新を行う。バイナリは Submit API 経由で配布される。
 
@@ -846,7 +910,7 @@ $ cjob update --version 1.3.1-beta.1
 更新が完了しました。(1.3.1-beta.1)
 ```
 
-## 16. `cjob flavor` の動作
+## 17. `cjob flavor` の動作
 
 `GET /v1/flavors` を呼び出し、利用可能な ResourceFlavor の一覧とリソース上限を表示する。認証不要のエンドポイントを使用するため、ServiceAccount JWT がなくても実行できる。
 

--- a/docs_en/architecture/cjobctl.md
+++ b/docs_en/architecture/cjobctl.md
@@ -115,13 +115,83 @@ Node name is obtained by the Watcher from the Pod's `spec.nodeName` during RUNNI
 
 The Daily Usage in `usage list` is displayed in ascending date order (oldest date first) by default. The `--namespace` option filters to data for a specific namespace only (applies to all sections: Daily / 7-Day Window / DRF).
 
-The DRF dominant share calculation in `usage list` uses the same formula as the Dispatcher (`server/src/cjob/dispatcher/scheduler.py`):
+#### `cjobctl usage list`
+
+Reads each namespace's resource consumption from the `namespace_daily_usage` table and prints three sections in order. The output order is always fixed; if no data exists, it prints `No usage data found.` and exits.
+
+Column schemas and unit conversions for each section:
+
+**Daily Usage**
+
+| Column | Description |
+|---|---|
+| `NAMESPACE` | User namespace |
+| `DATE` | `usage_date` (YYYY-MM-DD) |
+| `CPU (core·h)` | `SUM(cpu_millicores_seconds) / 1000 / 3600` |
+| `Mem (GiB·h)` | `SUM(memory_mib_seconds) / 1024 / 3600` |
+| `GPU (h)` | `SUM(gpu_seconds) / 3600` |
+
+The primary key of `namespace_daily_usage` is the composite key `(namespace, usage_date, flavor)`, so multiple rows exist for the same `(namespace, date)` — one per flavor. Daily Usage aggregates across flavors by using `GROUP BY namespace, usage_date`, so even with multiple flavors each date collapses to a single row. Order is `ORDER BY usage_date ASC, namespace ASC`.
+
+**N-Day Window Aggregate**
+
+| Column | Description |
+|---|---|
+| `NAMESPACE` | User namespace |
+| `CPU (core·h)` | Sum over the past N days (same unit conversion as Daily Usage) |
+| `Mem (GiB·h)` | Same |
+| `GPU (h)` | Same |
+
+The aggregation window size N is read from the key `FAIR_SHARE_WINDOW_DAYS` in the `cjob-config` ConfigMap in the `cjob-system` namespace (fallback is 7 days if retrieval fails or the key is absent). The section header reflects the actual value used, e.g., `=== N-Day Window Aggregate ===`. The SQL condition is `usage_date > CURRENT_DATE - N`.
+
+**DRF Dominant Share**
+
+| Column | Description |
+|---|---|
+| `NAMESPACE` | User namespace |
+| `CPU (core·h)` | Sum across flavors over the past N days (same as Window Aggregate) |
+| `Mem (GiB·h)` | Same |
+| `GPU (h)` | Same |
+| `WEIGHT` | `namespace_weights.weight` (defaults to 1.0 when the row is absent) |
+| `DOM_SHARE` | Weighted DRF score divided by the namespace weight |
+
+The formula is identical to the Dispatcher (`server/src/cjob/dispatcher/scheduler.py`): compute `dominant_share = GREATEST(cpu_share, mem_share, gpu_share)` per flavor, then weight each by `flavor_quotas.drf_weight` and sum within the namespace:
 
 ```
-dominant_share = GREATEST(cpu_share, mem_share, gpu_share) / weight
+window_seconds        = N × 86400
+cpu_share(f)          = cpu_millicores_seconds(ns,f) / (cap_cpu(f) × window_seconds)
+mem_share(f)          = memory_mib_seconds(ns,f)     / (cap_mem(f) × window_seconds)
+gpu_share(f)          = gpu_seconds(ns,f)            / (cap_gpu(f) × window_seconds)
+dominant_share(ns,f)  = MAX(cpu_share, mem_share, gpu_share)
+drf_score(ns)         = Σ_f dominant_share(ns,f) × drf_weight(f)
+DOM_SHARE(ns)         = drf_score(ns) / namespace_weight(ns)
 ```
 
-Cluster total resources are obtained via `SUM()` from the DB's `node_resources` table. If the table is empty, the dominant share column displays `N/A` (the Dispatcher disables DRF sorting and falls back to namespace name order, but cjobctl is a display tool so it explicitly indicates that calculation is not possible).
+The per-flavor capacity `cap_*` uses the `node_resources` allocatable total clamped by the `flavor_quotas` nominalQuota (`min(allocatable, nominalQuota)`). If `node_resources` is empty or the flavor is missing from `flavor_quotas`, allocatable is used as-is as a fallback. If `node_resources` is entirely empty, the DRF section is replaced with `No node_resources data. DRF disabled.` (the Dispatcher disables DRF sorting and falls back to namespace name order, but cjobctl is a display tool so it explicitly indicates that calculation is not possible).
+
+Rows are ordered by `DOM_SHARE` ascending (namespaces with lower consumption first). Namespaces with `WEIGHT = 0` are placed at the end by treating `DOM_SHARE` as effectively `inf`.
+
+Output example (`FAIR_SHARE_WINDOW_DAYS=7`, cpu-flavor-only cluster):
+
+```
+=== Daily Usage ===
+NAMESPACE            DATE             CPU (core·h)    Mem (GiB·h)    GPU (h)
+user-alice           2026-04-05               12.0           48.0        0.0
+user-bob             2026-04-05                4.0           16.0        0.0
+user-alice           2026-04-06                8.0           32.0        0.0
+
+=== 7-Day Window Aggregate ===
+NAMESPACE              CPU (core·h)    Mem (GiB·h)    GPU (h)
+user-alice                     20.0           80.0        0.0
+user-bob                        4.0           16.0        0.0
+
+=== DRF Dominant Share ===
+NAMESPACE              CPU (core·h)    Mem (GiB·h)    GPU (h)   WEIGHT        DOM_SHARE
+user-bob                        4.0           16.0        0.0        1         0.001488
+user-alice                     20.0           80.0        0.0        1         0.007440
+```
+
+In multi-flavor clusters, the Daily Usage section collapses to one row per `(namespace, date)` and does not show a per-flavor breakdown (use `cjob usage` if a per-flavor breakdown is needed). DRF Dominant Share computes dominant share per flavor and combines them using `drf_weight`.
 
 #### `cjobctl usage quota`
 

--- a/docs_en/architecture/cjobctl.md
+++ b/docs_en/architecture/cjobctl.md
@@ -191,7 +191,7 @@ user-bob                        4.0           16.0        0.0        1         0
 user-alice                     20.0           80.0        0.0        1         0.007440
 ```
 
-In multi-flavor clusters, the Daily Usage section collapses to one row per `(namespace, date)` and does not show a per-flavor breakdown (use `cjob usage` if a per-flavor breakdown is needed). DRF Dominant Share computes dominant share per flavor and combines them using `drf_weight`.
+In multi-flavor clusters, the Daily Usage section collapses to one row per `(namespace, date)` and does not show a per-flavor breakdown. No CLI command currently exposes per-flavor daily usage; if a per-flavor breakdown is needed, query `namespace_daily_usage` directly. DRF Dominant Share internally computes dominant share per flavor and combines them using `drf_weight`, but the output does not include a flavor column and only shows per-namespace aggregated values.
 
 #### `cjobctl usage quota`
 

--- a/docs_en/architecture/cli.md
+++ b/docs_en/architecture/cli.md
@@ -676,7 +676,71 @@ cjob release 1,3,5
 cjob release --all
 ```
 
-## 13. `cjob reset` Behavior
+## 13. `cjob set` Behavior
+
+For jobs in QUEUED or HELD state, overrides the resource request, flavor, and time limit that will be passed to the Dispatcher. Exits with an error if no field is specified.
+
+The job_id specification format is the same as `cjob cancel`, supporting single, range, and combined formats. Single-id invocations call `POST /v1/jobs/{job_id}/set`; multi-id invocations call `POST /v1/jobs/set`.
+
+### Modifiable Fields
+
+| Option | Type | Description |
+|---|---|---|
+| `--cpu <cpu>` | string | CPU request (e.g., `4`, `2000m`) |
+| `--memory <memory>` | string | Memory request (e.g., `16Gi`, `16384Mi`) |
+| `--gpu <N>` | integer | Number of GPUs |
+| `--flavor <name>` | string | ResourceFlavor name |
+| `--time-limit <duration>` | string | Execution time limit (e.g., `12h`, `30m`); converted to seconds before sending to the API |
+
+Fields not specified are left unchanged. Value parsing (e.g., `parse_duration`) reuses the same utilities as `cjob add`.
+
+### Target Job Conditions
+
+The API enforces the following state checks:
+
+- Jobs in any state other than `QUEUED` / `HELD` are placed in `skipped` (RUNNING / DISPATCHING / DISPATCHED / SUCCEEDED / FAILED / CANCELLED / DELETING — jobs that have already been handed off to K8s or completed are not modifiable).
+- Nonexistent job_ids are placed in `not_found`.
+
+### Behavior
+
+```
+# Note: The CLI is implemented in Rust. The following is pseudocode for conceptual explanation.
+
+fn cmd_set(expr, cpu, memory, gpu, flavor, time_limit):
+    if all parameters are None:
+        Error exit: "specify at least one parameter to modify (--cpu, --memory, --gpu, --flavor, --time-limit)"
+
+    time_limit_seconds = convert time_limit to seconds (when specified)
+
+    job_ids = parse_job_ids(expr)   // Shares the same parse logic as cancel
+    if len(job_ids) == 1:
+        Send parameters to POST /v1/jobs/{job_id}/set
+        Display "Job {job_id}: {status}"
+    else:
+        Send job_ids and parameters to POST /v1/jobs/set
+        Receive result:
+            If modified: Display "Modified: [job_ids]"
+            If skipped: Display "Skipped (not QUEUED / HELD): [job_ids]"
+            If not_found: Display "Not found: [job_ids]"
+```
+
+### Usage Examples
+
+```bash
+# Change only the flavor of a single job
+cjob set 5 --flavor cpu-sub
+
+# Change resource request and time limit for multiple jobs at once
+cjob set 10,11,12 --cpu 4 --memory 16Gi --time-limit 12h
+
+# Range + individual specification
+cjob set 10-20,25,30 --cpu 8
+
+# Feed IDs from cjob list (switch flavor while keeping jobs QUEUED)
+cjob set $(cjob list --status QUEUED --flavor cpu --format ids) --flavor cpu-sub
+```
+
+## 14. `cjob reset` Behavior
 
 1. Retrieves job list with `GET /v1/jobs`, retains `log_base_dir` from the response, and checks in the following order:
    - If any `DELETING` jobs exist: Displays "Previous reset process has not yet completed. Please wait a moment and try again." and aborts
@@ -702,7 +766,7 @@ Delete all 15 jobs and logs. Are you sure? [y/N] y
 Reset has started. Please wait for background cleanup to complete.
 ```
 
-## 14. `cjob usage` Behavior
+## 15. `cjob usage` Behavior
 
 Calls `GET /v1/usage` and displays daily resource usage for the past `FAIR_SHARE_WINDOW_DAYS` days.
 
@@ -770,7 +834,7 @@ Resource Usage (past 7 days)
   Total                    44.5           89.0
 ```
 
-## 15. `cjob update` Behavior
+## 16. `cjob update` Behavior
 
 Manages CLI binary versioning and updates. Binaries are distributed via the Submit API.
 
@@ -848,7 +912,7 @@ Update? 1.2.0 → 1.3.1-beta.1 [y/N] y
 Update complete. (1.3.1-beta.1)
 ```
 
-## 16. `cjob flavor` Behavior
+## 17. `cjob flavor` Behavior
 
 Calls `GET /v1/flavors` and displays the list of available ResourceFlavors and their resource limits. Uses an authentication-free endpoint, so it can be executed without a ServiceAccount JWT.
 


### PR DESCRIPTION
## Summary
- Add a dedicated `#### cjobctl usage list` subsection to `docs/architecture/cjobctl.md` covering Daily Usage / N-Day Window Aggregate / DRF Dominant Share column schemas, the `(namespace, usage_date)` group-by that collapses per-flavor rows (the behavior fixed in ee4b1d9), and the full DRF formula including flavor nominalQuota clamping.
- Add section `## 13. cjob set の動作` to `docs/architecture/cli.md` modeled after cancel/hold/release — modifiable fields, QUEUED/HELD state restrictions, single vs bulk endpoint routing, and output format. Sections 13–16 are renumbered to 14–17.
- Mirror both changes in `docs_en/`.
- Correct a follow-up factual error: `cjob usage` does not expose a per-flavor breakdown either, so the note now states that no CLI currently surfaces per-flavor daily usage and users must query `namespace_daily_usage` directly.

These gaps were found during a docs-vs-implementation consistency check on recently touched areas. The implementation, API spec, and user_guide were already consistent — this PR only catches the design docs up.

## Test plan
- [x] `docs/architecture/cjobctl.md` section numbering and table rendering verified
- [x] `docs/architecture/cli.md` section numbering confirmed sequential (1–17), no stale cross-references to renumbered sections
- [x] DRF formula in the new subsection matches `ctl/src/cmd/usage.rs` (per-flavor dominant share × `drf_weight`, divided by namespace weight)
- [x] `cjob set` fields match `cli/src/main.rs::cmd_set` (cpu, memory, gpu, flavor, time-limit; at-least-one validation; single vs bulk routing)
- [x] `cjob usage` output columns verified in `cli/src/main.rs::cmd_usage` — confirmed no flavor column
- [x] English docs reflect the same changes and section renumbering

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)