### PR TITLE
Add --flavor option to cjobctl usage list (#181)

### DIFF
--- a/ctl/src/cmd/usage.rs
+++ b/ctl/src/cmd/usage.rs
@@ -108,11 +108,36 @@ async fn fetch_window_days(k8s_client: &kube::Client, system_ns: &str) -> i32 {
     }
 }
 
-pub async fn list(client: &Client, k8s_client: &kube::Client, system_ns: &str, namespace: Option<&str>) -> Result<()> {
+pub async fn list(
+    client: &Client,
+    k8s_client: &kube::Client,
+    system_ns: &str,
+    namespace: Option<&str>,
+    flavor: Option<&str>,
+) -> Result<()> {
+    // Validate --flavor against flavor_quotas (same policy as set-drf-weight).
+    if let Some(f) = flavor {
+        let row = client
+            .query_one(
+                "SELECT COUNT(*)::BIGINT FROM flavor_quotas WHERE flavor = $1",
+                &[&f],
+            )
+            .await?;
+        let count: i64 = row.get(0);
+        if count == 0 {
+            bail!(
+                "Flavor '{}' not found in flavor_quotas. \
+                 Ensure the Watcher has synced the ClusterQueue.",
+                f,
+            );
+        }
+    }
+
     // 1. Daily raw data
     // namespace_daily_usage の主キーは (namespace, usage_date, flavor) の複合キーで、
     // 同じ (namespace, date) に対して flavor ごとに行が存在する。Daily Usage の
     // 表示では flavor をまたいで集計するため、namespace と usage_date で GROUP BY する。
+    // --flavor 指定時は AND flavor = $2 で対象 flavor のレコードのみに絞り込む。
     let daily_rows = client
         .query(
             "SELECT namespace, usage_date, \
@@ -121,18 +146,26 @@ pub async fn list(client: &Client, k8s_client: &kube::Client, system_ns: &str, n
                     SUM(gpu_seconds)::BIGINT AS gpu_seconds \
              FROM namespace_daily_usage \
              WHERE ($1::TEXT IS NULL OR namespace = $1) \
+               AND ($2::TEXT IS NULL OR flavor = $2) \
              GROUP BY namespace, usage_date \
              ORDER BY usage_date ASC, namespace ASC",
-            &[&namespace],
+            &[&namespace, &flavor],
         )
         .await?;
 
     if daily_rows.is_empty() {
-        println!("No usage data found.");
+        if let Some(f) = flavor {
+            println!("No usage data found for flavor '{}'.", f);
+        } else {
+            println!("No usage data found.");
+        }
         return Ok(());
     }
 
-    println!("=== Daily Usage ===");
+    match flavor {
+        Some(f) => println!("=== Daily Usage (flavor: {}) ===", f),
+        None => println!("=== Daily Usage ==="),
+    }
     println!(
         "{:<20} {:<12} {:>14} {:>14} {:>10}",
         "NAMESPACE", "DATE", "CPU (core·h)", "Mem (GiB·h)", "GPU (h)"
@@ -157,7 +190,10 @@ pub async fn list(client: &Client, k8s_client: &kube::Client, system_ns: &str, n
     let window_days = fetch_window_days(k8s_client, system_ns).await;
     let window_days_i32: i32 = window_days;
     println!();
-    println!("=== {}-Day Window Aggregate ===", window_days);
+    match flavor {
+        Some(f) => println!("=== {}-Day Window Aggregate (flavor: {}) ===", window_days, f),
+        None => println!("=== {}-Day Window Aggregate ===", window_days),
+    }
     let window_rows = client
         .query(
             "SELECT namespace, \
@@ -167,8 +203,9 @@ pub async fn list(client: &Client, k8s_client: &kube::Client, system_ns: &str, n
              FROM namespace_daily_usage \
              WHERE usage_date > CURRENT_DATE - $2::INT \
                AND ($1::TEXT IS NULL OR namespace = $1) \
+               AND ($3::TEXT IS NULL OR flavor = $3) \
              GROUP BY namespace ORDER BY namespace",
-            &[&namespace, &window_days_i32],
+            &[&namespace, &window_days_i32, &flavor],
         )
         .await?;
 
@@ -191,7 +228,13 @@ pub async fn list(client: &Client, k8s_client: &kube::Client, system_ns: &str, n
     }
 
     // 3. DRF dominant share (per-flavor method)
+    // DRF は定義上 flavor を跨いで重み付き合算するスコアのため、--flavor 指定時は
+    // 計算・出力を完全にスキップし、代わりに 1 行の注記を出す。
     println!();
+    if flavor.is_some() {
+        println!("DRF Dominant Share is computed across all flavors; pass no --flavor to see it.");
+        return Ok(());
+    }
     println!("=== DRF Dominant Share ===");
 
     let flavor_caps = fetch_flavor_caps(client).await;

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -137,6 +137,9 @@ enum UsageCommands {
         /// Filter by namespace
         #[arg(long)]
         namespace: Option<String>,
+        /// Filter by ResourceFlavor (suppresses DRF section)
+        #[arg(long)]
+        flavor: Option<String>,
     },
     /// Reset usage data
     Reset {
@@ -365,9 +368,16 @@ async fn main() -> Result<()> {
             let config = config::Config::load()?;
             let conn = db::connect(&config.database, config.system_namespace()).await?;
             match command {
-                UsageCommands::List { namespace } => {
+                UsageCommands::List { namespace, flavor } => {
                     let k8s_client = k8s::client().await?;
-                    cmd::usage::list(&conn.client, &k8s_client, config.system_namespace(), namespace.as_deref()).await
+                    cmd::usage::list(
+                        &conn.client,
+                        &k8s_client,
+                        config.system_namespace(),
+                        namespace.as_deref(),
+                        flavor.as_deref(),
+                    )
+                    .await
                 }
                 UsageCommands::Reset { namespace, all } => {
                     cmd::usage::reset(&conn.client, namespace.as_deref(), all).await

--- a/docs/architecture/cjobctl.md
+++ b/docs/architecture/cjobctl.md
@@ -107,15 +107,15 @@ namespace = "cjob-system"   # 省略時デフォルト
 
 | コマンド | 概要 | 対象テーブル |
 |---|---|---|
-| `cjobctl usage list [--namespace <ns>]` | 日別消費量・7日ウィンドウ集計・DRF dominant share | `namespace_daily_usage`, `namespace_weights` |
+| `cjobctl usage list [--namespace <ns>] [--flavor <name>]` | 日別消費量・7日ウィンドウ集計・DRF dominant share | `namespace_daily_usage`, `namespace_weights`, `flavor_quotas` |
 | `cjobctl usage reset [--namespace <ns> \| --all]` | 消費量データの削除 | `namespace_daily_usage` |
 | `cjobctl usage quota [--namespace <ns>]` | 全 namespace の ResourceQuota 使用状況 | `namespace_resource_quotas` + K8s namespace 一覧 |
 
-`usage list` の Daily Usage はデフォルトで日付昇順（古い日付が上）で表示する。`--namespace` オプションで特定 namespace のデータのみに絞り込める（Daily / 7-Day Window / DRF すべてのセクションに適用）。
+`usage list` の Daily Usage はデフォルトで日付昇順（古い日付が上）で表示する。`--namespace` オプションで特定 namespace のデータのみに絞り込める（Daily / 7-Day Window / DRF すべてのセクションに適用）。`--flavor` オプションで特定 ResourceFlavor のレコードのみに絞り込める（Daily / N-Day Window に適用、DRF セクションは非表示となる。詳細は後述）。`--namespace` と `--flavor` は併用可能で、両方指定した場合は AND 条件で絞り込む。
 
 #### `cjobctl usage list`
 
-`namespace_daily_usage` テーブルから各 namespace のリソース消費量を読み出し、3 つのセクションを順に出力する。出力は常にこの順序で、データが存在しない場合は `No usage data found.` を表示して終了する。
+`namespace_daily_usage` テーブルから各 namespace のリソース消費量を読み出し、3 つのセクションを順に出力する。出力は常にこの順序で、データが存在しない場合は `No usage data found.` を表示して終了する（`--flavor` 指定時は `No usage data found for flavor '<name>'.` を表示する）。
 
 各セクションのカラム構成と単位換算:
 
@@ -129,7 +129,7 @@ namespace = "cjob-system"   # 省略時デフォルト
 | `Mem (GiB·h)` | `SUM(memory_mib_seconds) / 1024 / 3600` |
 | `GPU (h)` | `SUM(gpu_seconds) / 3600` |
 
-`namespace_daily_usage` の主キーは `(namespace, usage_date, flavor)` の複合キーで、同じ `(namespace, date)` に対して flavor ごとに行が存在する。Daily Usage では flavor をまたいで集計するため、`GROUP BY namespace, usage_date` で合算する（複数 flavor がある場合でも同一日付が 1 行に統合される）。並び順は `ORDER BY usage_date ASC, namespace ASC`。
+`namespace_daily_usage` の主キーは `(namespace, usage_date, flavor)` の複合キーで、同じ `(namespace, date)` に対して flavor ごとに行が存在する。Daily Usage では flavor をまたいで集計するため、`GROUP BY namespace, usage_date` で合算する（複数 flavor がある場合でも同一日付が 1 行に統合される）。並び順は `ORDER BY usage_date ASC, namespace ASC`。`--flavor <name>` 指定時は `WHERE` 句に `AND flavor = $flavor` を追加し、指定 flavor のレコードのみを集計する。この場合、セクションヘッダーは `=== Daily Usage (flavor: <name>) ===` となり、flavor 合算結果と区別できる。
 
 **N-Day Window Aggregate**
 
@@ -140,7 +140,7 @@ namespace = "cjob-system"   # 省略時デフォルト
 | `Mem (GiB·h)` | 同上 |
 | `GPU (h)` | 同上 |
 
-集計ウィンドウ日数 N は `cjob-system` namespace の ConfigMap `cjob-config` のキー `FAIR_SHARE_WINDOW_DAYS` から取得する（取得失敗時・キー未設定時は 7 日）。セクションヘッダーには実際に使用した日数が `=== N-Day Window Aggregate ===` として反映される。SQL 条件は `usage_date > CURRENT_DATE - N`。
+集計ウィンドウ日数 N は `cjob-system` namespace の ConfigMap `cjob-config` のキー `FAIR_SHARE_WINDOW_DAYS` から取得する（取得失敗時・キー未設定時は 7 日）。セクションヘッダーには実際に使用した日数が `=== N-Day Window Aggregate ===` として反映される。SQL 条件は `usage_date > CURRENT_DATE - N`。`--flavor <name>` 指定時は `WHERE` 句に `AND flavor = $flavor` を追加し、セクションヘッダーは `=== N-Day Window Aggregate (flavor: <name>) ===` となる。
 
 **DRF Dominant Share**
 
@@ -169,6 +169,8 @@ DOM_SHARE(ns)         = drf_score(ns) / namespace_weight(ns)
 
 行の並び順は `DOM_SHARE` 昇順（=消費の少ない namespace が上）。`WEIGHT = 0` の namespace は `DOM_SHARE` を `inf` 相当として末尾に配置する。
 
+`--flavor <name>` 指定時、DRF Dominant Share セクションは計算・出力を完全にスキップする。DRF は定義上 flavor をまたいで重み付き合算するスコアであり、単一 flavor のみを対象にすると DRF の目的（複数リソース次元を跨いだ公平性）が失われるためである（計算結果は単に 1 flavor の dominant share × `drf_weight` となり、誤解を招く）。DRF セクションの代わりに 1 行の注記 `DRF Dominant Share is computed across all flavors; pass no --flavor to see it.` を出力する。
+
 出力例（`FAIR_SHARE_WINDOW_DAYS=7`、cpu flavor のみの構成）:
 
 ```
@@ -189,7 +191,9 @@ user-bob                        4.0           16.0        0.0        1         0
 user-alice                     20.0           80.0        0.0        1         0.007440
 ```
 
-複数 flavor がある構成では、Daily Usage セクションは `(namespace, date)` 単位で 1 行に統合され、flavor ごとの内訳は表示されない。flavor 別の内訳を閲覧する CLI コマンドは現時点では存在せず、必要な場合は `namespace_daily_usage` を直接参照する必要がある。DRF Dominant Share は内部で flavor 単位に dominant share を計算し、`drf_weight` で重み付け合算するが、出力には flavor 列を含めず namespace 単位の集計値のみを表示する。
+複数 flavor がある構成では、`--flavor` オプション未指定時の Daily Usage セクションは `(namespace, date)` 単位で 1 行に統合され、flavor ごとの内訳は表示されない。flavor 別の内訳を確認したい場合は `cjobctl usage list --flavor <name>` を使用する（Daily Usage と N-Day Window Aggregate が指定 flavor のレコードのみで集計される）。DRF Dominant Share は内部で flavor 単位に dominant share を計算し、`drf_weight` で重み付け合算するが、出力には flavor 列を含めず namespace 単位の集計値のみを表示する。
+
+`--flavor` の引数に指定された名前は `flavor_quotas` テーブルで存在確認される。未登録の flavor 名が指定された場合は `Flavor '<name>' not found in flavor_quotas. Ensure the Watcher has synced the ClusterQueue.` を表示して異常終了する（`cjobctl cluster set-drf-weight` と同じ方針）。
 
 #### `cjobctl usage quota`
 

--- a/docs_en/architecture/cjobctl.md
+++ b/docs_en/architecture/cjobctl.md
@@ -109,15 +109,15 @@ Node name is obtained by the Watcher from the Pod's `spec.nodeName` during RUNNI
 
 | Command | Description | Target Table |
 |---|---|---|
-| `cjobctl usage list [--namespace <ns>]` | Daily consumption, 7-day window aggregation, DRF dominant share | `namespace_daily_usage`, `namespace_weights` |
+| `cjobctl usage list [--namespace <ns>] [--flavor <name>]` | Daily consumption, 7-day window aggregation, DRF dominant share | `namespace_daily_usage`, `namespace_weights`, `flavor_quotas` |
 | `cjobctl usage reset [--namespace <ns> \| --all]` | Delete consumption data | `namespace_daily_usage` |
 | `cjobctl usage quota [--namespace <ns>]` | ResourceQuota usage for all namespaces | `namespace_resource_quotas` + K8s namespace list |
 
-The Daily Usage in `usage list` is displayed in ascending date order (oldest date first) by default. The `--namespace` option filters to data for a specific namespace only (applies to all sections: Daily / 7-Day Window / DRF).
+The Daily Usage in `usage list` is displayed in ascending date order (oldest date first) by default. The `--namespace` option filters to data for a specific namespace only (applies to all sections: Daily / 7-Day Window / DRF). The `--flavor` option filters to records of a specific ResourceFlavor (applies to Daily / N-Day Window; the DRF section is suppressed — see below). `--namespace` and `--flavor` can be combined: when both are specified, they are applied as an AND condition.
 
 #### `cjobctl usage list`
 
-Reads each namespace's resource consumption from the `namespace_daily_usage` table and prints three sections in order. The output order is always fixed; if no data exists, it prints `No usage data found.` and exits.
+Reads each namespace's resource consumption from the `namespace_daily_usage` table and prints three sections in order. The output order is always fixed; if no data exists, it prints `No usage data found.` and exits (when `--flavor` is specified, the message is `No usage data found for flavor '<name>'.`).
 
 Column schemas and unit conversions for each section:
 
@@ -131,7 +131,7 @@ Column schemas and unit conversions for each section:
 | `Mem (GiB·h)` | `SUM(memory_mib_seconds) / 1024 / 3600` |
 | `GPU (h)` | `SUM(gpu_seconds) / 3600` |
 
-The primary key of `namespace_daily_usage` is the composite key `(namespace, usage_date, flavor)`, so multiple rows exist for the same `(namespace, date)` — one per flavor. Daily Usage aggregates across flavors by using `GROUP BY namespace, usage_date`, so even with multiple flavors each date collapses to a single row. Order is `ORDER BY usage_date ASC, namespace ASC`.
+The primary key of `namespace_daily_usage` is the composite key `(namespace, usage_date, flavor)`, so multiple rows exist for the same `(namespace, date)` — one per flavor. Daily Usage aggregates across flavors by using `GROUP BY namespace, usage_date`, so even with multiple flavors each date collapses to a single row. Order is `ORDER BY usage_date ASC, namespace ASC`. When `--flavor <name>` is specified, `AND flavor = $flavor` is added to the `WHERE` clause so that only records of the specified flavor are aggregated. In that case the section header becomes `=== Daily Usage (flavor: <name>) ===`, making it distinguishable from the flavor-merged result.
 
 **N-Day Window Aggregate**
 
@@ -142,7 +142,7 @@ The primary key of `namespace_daily_usage` is the composite key `(namespace, usa
 | `Mem (GiB·h)` | Same |
 | `GPU (h)` | Same |
 
-The aggregation window size N is read from the key `FAIR_SHARE_WINDOW_DAYS` in the `cjob-config` ConfigMap in the `cjob-system` namespace (fallback is 7 days if retrieval fails or the key is absent). The section header reflects the actual value used, e.g., `=== N-Day Window Aggregate ===`. The SQL condition is `usage_date > CURRENT_DATE - N`.
+The aggregation window size N is read from the key `FAIR_SHARE_WINDOW_DAYS` in the `cjob-config` ConfigMap in the `cjob-system` namespace (fallback is 7 days if retrieval fails or the key is absent). The section header reflects the actual value used, e.g., `=== N-Day Window Aggregate ===`. The SQL condition is `usage_date > CURRENT_DATE - N`. When `--flavor <name>` is specified, `AND flavor = $flavor` is added to the `WHERE` clause and the section header becomes `=== N-Day Window Aggregate (flavor: <name>) ===`.
 
 **DRF Dominant Share**
 
@@ -171,6 +171,8 @@ The per-flavor capacity `cap_*` uses the `node_resources` allocatable total clam
 
 Rows are ordered by `DOM_SHARE` ascending (namespaces with lower consumption first). Namespaces with `WEIGHT = 0` are placed at the end by treating `DOM_SHARE` as effectively `inf`.
 
+When `--flavor <name>` is specified, the DRF Dominant Share section is skipped entirely (both computation and output). DRF is by definition a score that combines weighted dominant shares across flavors, so restricting it to a single flavor defeats the point of DRF (the result would merely be the single flavor's dominant share × `drf_weight`, which is misleading). In place of the section, a single-line note `DRF Dominant Share is computed across all flavors; pass no --flavor to see it.` is printed.
+
 Output example (`FAIR_SHARE_WINDOW_DAYS=7`, cpu-flavor-only cluster):
 
 ```
@@ -191,7 +193,9 @@ user-bob                        4.0           16.0        0.0        1         0
 user-alice                     20.0           80.0        0.0        1         0.007440
 ```
 
-In multi-flavor clusters, the Daily Usage section collapses to one row per `(namespace, date)` and does not show a per-flavor breakdown. No CLI command currently exposes per-flavor daily usage; if a per-flavor breakdown is needed, query `namespace_daily_usage` directly. DRF Dominant Share internally computes dominant share per flavor and combines them using `drf_weight`, but the output does not include a flavor column and only shows per-namespace aggregated values.
+In multi-flavor clusters, when `--flavor` is not specified the Daily Usage section collapses to one row per `(namespace, date)` and does not show a per-flavor breakdown. To see a per-flavor breakdown, use `cjobctl usage list --flavor <name>` (Daily Usage and N-Day Window Aggregate will then aggregate only records of the specified flavor). DRF Dominant Share internally computes dominant share per flavor and combines them using `drf_weight`, but the output does not include a flavor column and only shows per-namespace aggregated values.
+
+The name passed to `--flavor` is validated against the `flavor_quotas` table. If an unregistered flavor name is specified, the command prints `Flavor '<name>' not found in flavor_quotas. Ensure the Watcher has synced the ClusterQueue.` and exits with an error (same policy as `cjobctl cluster set-drf-weight`).
 
 #### `cjobctl usage quota`
 


### PR DESCRIPTION
## Summary
- `cjobctl usage list` に `--flavor <name>` オプションを追加し、指定した ResourceFlavor のレコードのみで Daily Usage / N-Day Window Aggregate を集計する。セクションヘッダーには flavor 名を併記して合算結果と区別できるようにする。
- DRF Dominant Share は定義上 flavor を跨いで重み付き合算するスコアのため、`--flavor` 指定時は計算・出力を完全にスキップし、代わりに `DRF Dominant Share is computed across all flavors; pass no --flavor to see it.` の 1 行注記を出力する。
- `--flavor` の引数は `flavor_quotas` テーブルで存在確認し、未登録の flavor 名には `cjobctl cluster set-drf-weight` と同一のエラーメッセージで異常終了する。
- `--namespace` との併用を AND 条件でサポート（`--namespace user-alice --flavor cpu` で絞り込み可能）。
- 日本語設計書 (`docs/architecture/cjobctl.md` §5.2) と英語版 (`docs_en/architecture/cjobctl.md`) を同期して更新。実装影響範囲は cjobctl のみで、API / Dispatcher / Watcher / DB スキーマには影響なし。

## Test plan
- [x] `cargo check` がクリーンに通ることを確認
- [x] `cjobctl usage list` （オプションなし）が従来どおり Daily / N-Day Window / DRF の 3 セクションを出力する
- [x] `cjobctl usage list --flavor cpu` が `=== Daily Usage (flavor: cpu) ===` と `=== N-Day Window Aggregate (flavor: cpu) ===` を出力し、DRF セクション相当に 1 行の注記が出る
- [x] `cjobctl usage list --namespace user-alice --flavor cpu` が AND 条件で絞り込まれる
- [x] `cjobctl usage list --flavor nonexistent` がエラー終了し `Flavor 'nonexistent' not found in flavor_quotas.` を出力する
- [x] 指定 flavor に該当データがない場合、`No usage data found for flavor '<name>'.` が出力される

## Post-apply actions
- cjobctl のビルドと再配布

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)