### PR TITLE
chore(claude): harden autonomous-mode config and Claude Code tool usage

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,10 +34,6 @@
       "Bash(uv sync:*)",
       "Bash(pip3 install:*)",
       "Bash(cross --version)",
-      "Bash(find . -type f \\\\\\(-name *.py -o -name *.rs -o -name *.toml -o -name Dockerfile* -o -name *.yaml -o -name *.yml \\\\\\))",
-      "Bash(find . -type f \\\\\\(-name *.py -o -name *.rs -o -name Dockerfile* -o -name *.toml -o -name *.yaml -o -name *.yml \\\\\\) -not -path ./.git/*)",
-      "Bash(find . -type f \\\\\\(-name *.yaml -o -name *.yml \\\\\\))",
-      "Bash(find . -type f \\\\\\(-name *.sh -o -name *.bash -o -name *.json -o -name Makefile \\\\\\) ! -path */.venv/* ! -path */target/* ! -path */.git/*)",
       "Read(//tmp/**)"
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(kubectl:*)"
+    ],
+    "allow": [
+      "Edit",
+      "Write",
+      "Skill(create-pr)",
+      "WebSearch",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:kueue.sigs.k8s.io)",
+      "WebFetch(domain:volcano.sh)",
+      "WebFetch(domain:prometheus.io)",
+      "Bash(git -C:*)",
+      "Bash(git add:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git commit:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git push:*)",
+      "Bash(git rebase:*)",
+      "Bash(git show:*)",
+      "Bash(git stash:*)",
+      "Bash(git status:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(uv run:*)",
+      "Bash(uv pip install:*)",
+      "Bash(uv sync:*)",
+      "Bash(pip3 install:*)",
+      "Bash(cross --version)",
+      "Bash(find . -type f \\\\\\(-name *.py -o -name *.rs -o -name *.toml -o -name Dockerfile* -o -name *.yaml -o -name *.yml \\\\\\))",
+      "Bash(find . -type f \\\\\\(-name *.py -o -name *.rs -o -name Dockerfile* -o -name *.toml -o -name *.yaml -o -name *.yml \\\\\\) -not -path ./.git/*)",
+      "Bash(find . -type f \\\\\\(-name *.yaml -o -name *.yml \\\\\\))",
+      "Bash(find . -type f \\\\\\(-name *.sh -o -name *.bash -o -name *.json -o -name Makefile \\\\\\) ! -path */.venv/* ! -path */target/* ! -path */.git/*)",
+      "Read(//tmp/**)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,3 +202,4 @@ issue に `autonomous` ラベルが付いていても、以下のいずれかに
 
 - プッシュ前には毎回必ずユーザーの確認を取ること（自動化モードの場合を除く）
 - コミット・ブランチ作成・PR 作成時は [Git 運用規則](docs/git_conventions.md) に従うこと。
+- 別ディレクトリから git を実行する場合は `cd <path> && git ...` の複合コマンドを使わず、`git -C <path> ...` を使うこと。Claude Code の harness は bare repository attack 対策として `cd` + `git` の複合コマンドを承認待ちにするため、自動化モードでも中断される。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,3 +203,9 @@ issue に `autonomous` ラベルが付いていても、以下のいずれかに
 - プッシュ前には毎回必ずユーザーの確認を取ること（自動化モードの場合を除く）
 - コミット・ブランチ作成・PR 作成時は [Git 運用規則](docs/git_conventions.md) に従うこと。
 - 別ディレクトリから git を実行する場合は `cd <path> && git ...` の複合コマンドを使わず、`git -C <path> ...` を使うこと。Claude Code の harness は bare repository attack 対策として `cd` + `git` の複合コマンドを承認待ちにするため、自動化モードでも中断される。
+
+## Claude Code ツールの使用
+
+- ドキュメントや指示内でシェルの `find` や `grep` に言及があっても、Claude Code の dedicated tool（Glob / Grep）を優先して使うこと。Grep は ripgrep ベースで gitignore をデフォルトで尊重するため、`.venv` / `target` / `.git` 等の除外が自動で効き、`find ... ! -path */.venv/*` のような複雑な除外指定は不要。
+- ファイル列挙は Glob、または Grep の `output_mode="files_with_matches"` を使う。
+- Bash 経由で `find` / `grep` を実行しない（シェル依存の特殊ケースを除く）。


### PR DESCRIPTION
## Summary
- CLAUDE.md の Git 操作セクションに `git -C <path>` ルールを追記（`cd + git` 複合コマンドは Claude Code harness の bare repository attack 対策で承認待ちになり、自動化モードでも中断されるため）。
- CLAUDE.md に「Claude Code ツールの使用」セクションを新設し、ドキュメント内で `find` / `grep` に言及があっても dedicated tool（Glob / Grep）を優先するルールを明記。Grep は ripgrep ベースで gitignore を尊重するため、`.venv` / `target` / `.git` の除外も自動で効く。
- `.claude/settings.json` を新規追加し、プロジェクト共通の permissions を集約（Edit / Write / git / gh / uv / よく使う WebFetch ドメイン / kubectl deny）。これにより autonomous ラベル付き issue の /solve 実行時に permission mode を手動で切り替える必要がなくなる。
- settings.json から `Bash(find)` パターンは削除。Glob / Grep で完全に代替できるため。

## Test plan
- [x] `.claude/settings.json` の JSON 妥当性を確認
- [x] `.claude/settings.local.json` の JSON 妥当性を確認
- [x] Glob / Grep で従来の find パターンがカバーできることを手元で検証（ripgrep の gitignore 尊重で `.venv` / `target` が自動除外されることを確認）
- [x] `.claude/settings.json` / `.claude/settings.local.json` は Claude Code harness がハードコードで保護しており、allow リスト設定に関係なく変更時に承認を求めることを確認済み（公式ドキュメント: https://code.claude.com/docs/en/permissions）

🤖 Generated with [Claude Code](https://claude.com/claude-code)