### PR TITLE
docs: Clarify wrapper-script pitfall with $CJOB_INDEX in cjob sweep

### DIFF
--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -179,16 +179,29 @@ cjob delete --all
 - 0-origin（K8s の `JOB_COMPLETION_INDEX` と同一）
 - 値の範囲: `0` 〜 `completions - 1`
 
-スクリプトファイル内では `$CJOB_INDEX` 環境変数を直接参照できる。スクリプトファイルの中身はユーザーのシェルによる展開を受けないため、`_INDEX_` プレースホルダーを使わずに `$CJOB_INDEX` をそのまま記述できる。
+ジョブとして Pod 内で実行されるスクリプトファイル内では `$CJOB_INDEX` 環境変数を直接参照できる。スクリプトファイルの中身はユーザーシェルによる展開を受けないため、`_INDEX_` プレースホルダーを使わずに `$CJOB_INDEX` をそのまま記述できる。
 
 ```bash
-# run.sh
+# run.sh（Pod の中で実行される）
 echo "index is $CJOB_INDEX"
 python main.py --trial $CJOB_INDEX
 ```
 
 ```bash
 cjob sweep -n 10 --parallel 5 -- bash run.sh
+```
+
+**注意: `cjob sweep` を呼び出すラッパースクリプトの場合**
+
+上記の「スクリプトファイル」は Job Pod 内で実行される側のスクリプト（`run.sh`）を指す。これに対して `cjob sweep` コマンド自体をシェルスクリプトに書いて `bash jobscript.sh` のようにユーザーシェルで実行する場合、スクリプトの中身はユーザーシェルの変数展開を受ける。このとき `$CJOB_INDEX` は未定義のため空文字列に展開され、`cjob sweep` に渡る引数が欠落する。ラッパースクリプトでは必ず `_INDEX_` を使うこと（または `'$CJOB_INDEX'` のようにシングルクォートで展開を抑止する）。
+
+```bash
+# jobscript.sh - 手元の bash で実行するラッパースクリプト
+NUM_SEED=50
+cjob sweep -n ${NUM_SEED} -- python train.py --seed _INDEX_       # OK
+
+# NG: ${CJOB_INDEX} はユーザーシェルで展開され空文字列になる
+# cjob sweep -n ${NUM_SEED} -- python train.py --seed ${CJOB_INDEX}
 ```
 
 ## 4. `cjob add` の動作

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -59,10 +59,10 @@ cjob sweep -n 100 --parallel 10 -- python main.py --trial _INDEX_
 cjob sweep -n 50 --parallel 5 -- python train.py --seed _INDEX_
 ```
 
-ジョブとして実行されるスクリプトファイル（Job Pod の中で動くスクリプト）では `$CJOB_INDEX` という変数名で番号を直接参照できます。
+ジョブの本体として実行されるスクリプトの中では、`$CJOB_INDEX` という変数名で番号を直接参照できます。
 
 ```bash
-# run.sh の中身の例（Pod の中で実行される）
+# run.sh の中身の例（クラスタ側でジョブとして実行される）
 python train.py --config configs/config_${CJOB_INDEX}.yaml
 ```
 
@@ -70,20 +70,20 @@ python train.py --config configs/config_${CJOB_INDEX}.yaml
 cjob sweep -n 10 --parallel 5 -- bash run.sh
 ```
 
-**注意: `cjob sweep` を呼び出すラッパースクリプトの場合**
+**注意: `cjob sweep` を呼び出すシェルスクリプトの場合**
 
-`cjob sweep` コマンド自体をシェルスクリプトに記述して `bash myscript.sh` のように手元で実行する場合は、必ず `_INDEX_` を使ってください。スクリプトを実行するユーザーシェルが `$CJOB_INDEX` を展開しようとして空文字列に置き換えてしまい、`cjob sweep` に空の引数が渡ってしまいます。
+上の例の `run.sh` は「cjob がジョブとして動かすスクリプト」ですが、これと混同しやすいのが「`cjob sweep` コマンドそのものを書いておいて、手元の bash で実行するためのスクリプト」です。このようなスクリプトを `bash jobscript.sh` のように実行する場合は、必ず `_INDEX_` を使ってください。手元のシェルが `$CJOB_INDEX` を先に解釈して空文字列に置き換えてしまい、`cjob sweep` に空の引数が渡ってしまいます。
 
 ```bash
 # jobscript.sh - 手元の bash で実行するラッパースクリプト
 NUM_SEED=50
 cjob sweep -n ${NUM_SEED} -- python train.py --seed _INDEX_       # OK
 
-# NG: ${CJOB_INDEX} はユーザーシェルで展開され空文字列になる
+# NG: ${CJOB_INDEX} は手元のシェルで展開され空文字列になる
 # cjob sweep -n ${NUM_SEED} -- python train.py --seed ${CJOB_INDEX}
 ```
 
-どうしても `$CJOB_INDEX` の文字列そのものを渡したい場合は、シングルクォートで展開を抑止できます（`--seed '$CJOB_INDEX'`）。
+どうしても `$CJOB_INDEX` という文字列そのものを渡したい場合は、シングルクォートで囲むと展開されません（`--seed '$CJOB_INDEX'`）。
 
 ### 2.3 並列数の選び方
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -59,16 +59,31 @@ cjob sweep -n 100 --parallel 10 -- python main.py --trial _INDEX_
 cjob sweep -n 50 --parallel 5 -- python train.py --seed _INDEX_
 ```
 
-スクリプトファイルの中では `$CJOB_INDEX` という変数名で番号を直接参照できます。
+ジョブとして実行されるスクリプトファイル（Job Pod の中で動くスクリプト）では `$CJOB_INDEX` という変数名で番号を直接参照できます。
 
 ```bash
-# run.sh の中身の例
+# run.sh の中身の例（Pod の中で実行される）
 python train.py --config configs/config_${CJOB_INDEX}.yaml
 ```
 
 ```bash
 cjob sweep -n 10 --parallel 5 -- bash run.sh
 ```
+
+**注意: `cjob sweep` を呼び出すラッパースクリプトの場合**
+
+`cjob sweep` コマンド自体をシェルスクリプトに記述して `bash myscript.sh` のように手元で実行する場合は、必ず `_INDEX_` を使ってください。スクリプトを実行するユーザーシェルが `$CJOB_INDEX` を展開しようとして空文字列に置き換えてしまい、`cjob sweep` に空の引数が渡ってしまいます。
+
+```bash
+# jobscript.sh - 手元の bash で実行するラッパースクリプト
+NUM_SEED=50
+cjob sweep -n ${NUM_SEED} -- python train.py --seed _INDEX_       # OK
+
+# NG: ${CJOB_INDEX} はユーザーシェルで展開され空文字列になる
+# cjob sweep -n ${NUM_SEED} -- python train.py --seed ${CJOB_INDEX}
+```
+
+どうしても `$CJOB_INDEX` の文字列そのものを渡したい場合は、シングルクォートで展開を抑止できます（`--seed '$CJOB_INDEX'`）。
 
 ### 2.3 並列数の選び方
 

--- a/docs_en/architecture/cli.md
+++ b/docs_en/architecture/cli.md
@@ -181,16 +181,29 @@ cjob delete --all
 - 0-origin (same as K8s `JOB_COMPLETION_INDEX`)
 - Value range: `0` to `completions - 1`
 
-Within script files, the `$CJOB_INDEX` environment variable can be referenced directly. Since the contents of script files are not subject to shell expansion by the user's shell, `$CJOB_INDEX` can be written directly without using the `_INDEX_` placeholder.
+Within script files executed as the job inside the Pod, the `$CJOB_INDEX` environment variable can be referenced directly. The contents of such script files are not subject to shell expansion by the user's shell, so `$CJOB_INDEX` can be written directly without using the `_INDEX_` placeholder.
 
 ```bash
-# run.sh
+# run.sh (executed inside the Pod)
 echo "index is $CJOB_INDEX"
 python main.py --trial $CJOB_INDEX
 ```
 
 ```bash
 cjob sweep -n 10 --parallel 5 -- bash run.sh
+```
+
+**Note: Wrapper scripts that invoke `cjob sweep`**
+
+The "script files" above refer to the script that runs inside the Job Pod (`run.sh`). In contrast, if the `cjob sweep` command itself is written in a shell script that is executed on the user's shell (e.g., `bash jobscript.sh`), the script's contents are subject to the user's shell expansion. In that case `$CJOB_INDEX` is undefined and expands to an empty string, causing the argument to be missing when `cjob sweep` receives it. Wrapper scripts must use `_INDEX_` (or suppress expansion with single quotes, e.g., `'$CJOB_INDEX'`).
+
+```bash
+# jobscript.sh - wrapper script run by the user's bash
+NUM_SEED=50
+cjob sweep -n ${NUM_SEED} -- python train.py --seed _INDEX_       # OK
+
+# WRONG: ${CJOB_INDEX} is expanded by the user's shell into an empty string
+# cjob sweep -n ${NUM_SEED} -- python train.py --seed ${CJOB_INDEX}
 ```
 
 ## 4. `cjob add` Behavior

--- a/docs_en/user_guide.md
+++ b/docs_en/user_guide.md
@@ -61,10 +61,10 @@ cjob sweep -n 100 --parallel 10 -- python main.py --trial _INDEX_
 cjob sweep -n 50 --parallel 5 -- python train.py --seed _INDEX_
 ```
 
-Within job script files (scripts executed inside the Job Pod), you can reference the number directly using the variable `$CJOB_INDEX`.
+Inside a script that runs as the body of the job, you can reference the number directly using the variable `$CJOB_INDEX`.
 
 ```bash
-# Example content of run.sh (executed inside the Pod)
+# Example content of run.sh (executed on the cluster side as the job)
 python train.py --config configs/config_${CJOB_INDEX}.yaml
 ```
 
@@ -72,20 +72,20 @@ python train.py --config configs/config_${CJOB_INDEX}.yaml
 cjob sweep -n 10 --parallel 5 -- bash run.sh
 ```
 
-**Note: Wrapper scripts that invoke `cjob sweep`**
+**Note: Shell scripts that invoke `cjob sweep`**
 
-If you write the `cjob sweep` command itself inside a shell script and run it locally (e.g., `bash myscript.sh`), you must use `_INDEX_`. The user's shell expanding the script will try to resolve `$CJOB_INDEX` and substitute it with an empty string, leaving `cjob sweep` with a blank argument.
+`run.sh` above is the script that cjob runs as the job itself. This is easy to confuse with another case: a script that contains the `cjob sweep` command and that you run yourself on your local machine. For scripts of the latter kind, always use `_INDEX_`. Your local shell will otherwise expand `$CJOB_INDEX` before `cjob sweep` sees it, substituting an empty string and leaving the argument blank.
 
 ```bash
 # jobscript.sh - wrapper script run by your local bash
 NUM_SEED=50
 cjob sweep -n ${NUM_SEED} -- python train.py --seed _INDEX_       # OK
 
-# WRONG: ${CJOB_INDEX} is expanded by the user's shell into an empty string
+# WRONG: ${CJOB_INDEX} is expanded by your local shell into an empty string
 # cjob sweep -n ${NUM_SEED} -- python train.py --seed ${CJOB_INDEX}
 ```
 
-If you really need to pass the literal string `$CJOB_INDEX` through, use single quotes to suppress expansion (`--seed '$CJOB_INDEX'`).
+If you really need to pass the literal string `$CJOB_INDEX` through, wrap it in single quotes to suppress expansion (`--seed '$CJOB_INDEX'`).
 
 ### 2.3 Choosing the Parallelism Level
 

--- a/docs_en/user_guide.md
+++ b/docs_en/user_guide.md
@@ -61,16 +61,31 @@ cjob sweep -n 100 --parallel 10 -- python main.py --trial _INDEX_
 cjob sweep -n 50 --parallel 5 -- python train.py --seed _INDEX_
 ```
 
-Within script files, you can reference the number directly using the variable `$CJOB_INDEX`.
+Within job script files (scripts executed inside the Job Pod), you can reference the number directly using the variable `$CJOB_INDEX`.
 
 ```bash
-# Example content of run.sh
+# Example content of run.sh (executed inside the Pod)
 python train.py --config configs/config_${CJOB_INDEX}.yaml
 ```
 
 ```bash
 cjob sweep -n 10 --parallel 5 -- bash run.sh
 ```
+
+**Note: Wrapper scripts that invoke `cjob sweep`**
+
+If you write the `cjob sweep` command itself inside a shell script and run it locally (e.g., `bash myscript.sh`), you must use `_INDEX_`. The user's shell expanding the script will try to resolve `$CJOB_INDEX` and substitute it with an empty string, leaving `cjob sweep` with a blank argument.
+
+```bash
+# jobscript.sh - wrapper script run by your local bash
+NUM_SEED=50
+cjob sweep -n ${NUM_SEED} -- python train.py --seed _INDEX_       # OK
+
+# WRONG: ${CJOB_INDEX} is expanded by the user's shell into an empty string
+# cjob sweep -n ${NUM_SEED} -- python train.py --seed ${CJOB_INDEX}
+```
+
+If you really need to pass the literal string `$CJOB_INDEX` through, use single quotes to suppress expansion (`--seed '$CJOB_INDEX'`).
 
 ### 2.3 Choosing the Parallelism Level
 


### PR DESCRIPTION
## Summary

- Clarify that `$CJOB_INDEX` can only be referenced directly from **scripts executed inside the Job Pod** (e.g. `run.sh` in `cjob sweep -- bash run.sh`).
- Add an explicit pitfall note for **wrapper scripts** that invoke `cjob sweep` locally: the user's shell expands `$CJOB_INDEX` to an empty string before `cjob sweep` sees it, so these must use the `_INDEX_` placeholder (or single-quote the literal).
- Updated both `docs/user_guide.md` §2.2 and `docs/architecture/cli.md` §3.5, plus the English counterparts under `docs_en/`.

## Test plan

- [x] Read the updated sections and verify the wrapper-script example matches the reported reproduction
- [x] Reviewer sanity check that the wording distinguishes "script run inside Pod" from "script that calls cjob sweep locally"

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)