### PR TITLE
feat: Show retry_count and recent events in cjob/cjobctl status

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -66,6 +66,13 @@ pub struct JobSummary {
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
+pub struct JobEventItem {
+    pub event_type: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 pub struct JobDetailResponse {
     pub job_id: u32,
     pub status: String,
@@ -91,6 +98,14 @@ pub struct JobDetailResponse {
     pub completed_indexes: Option<String>,
     pub failed_indexes: Option<String>,
     pub node_name: Option<Vec<String>>,
+    #[serde(default)]
+    pub retry_count: u32,
+    #[serde(default)]
+    pub retry_after: Option<String>,
+    #[serde(default)]
+    pub events: Vec<JobEventItem>,
+    #[serde(default)]
+    pub earlier_events_count: u32,
 }
 
 #[derive(Debug, Serialize)]

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -1,4 +1,4 @@
-use crate::client::{JobDetailResponse, JobSummary};
+use crate::client::{JobDetailResponse, JobEventItem, JobSummary};
 
 pub fn print_job_ids(jobs: &[JobSummary]) {
     if jobs.is_empty() {
@@ -80,6 +80,31 @@ fn format_time_limit(job: &JobDetailResponse) -> String {
     limit_str
 }
 
+pub fn format_retry_lines(retry_count: u32, retry_after: Option<&str>) -> Option<String> {
+    if retry_count == 0 && retry_after.is_none() {
+        return None;
+    }
+    let after = retry_after.unwrap_or("-");
+    Some(format!(
+        "retry_count:   {}\nretry_after:   {}",
+        retry_count, after
+    ))
+}
+
+pub fn format_events_section(events: &[JobEventItem], earlier_events_count: u32) -> Option<String> {
+    if events.is_empty() {
+        return None;
+    }
+    let mut out = String::from("events:");
+    if earlier_events_count > 0 {
+        out.push_str(&format!("\n  ... {} earlier events", earlier_events_count));
+    }
+    for ev in events {
+        out.push_str(&format!("\n  {}  {}", ev.created_at, ev.event_type));
+    }
+    Some(out)
+}
+
 pub fn print_job_detail(job: &JobDetailResponse) {
     let is_sweep = job.completions.is_some();
 
@@ -144,6 +169,12 @@ pub fn print_job_detail(job: &JobDetailResponse) {
     if let Some(ref err) = job.last_error {
         println!("last_error:    {}", err);
     }
+    if let Some(retry) = format_retry_lines(job.retry_count, job.retry_after.as_deref()) {
+        println!("{}", retry);
+    }
+    if let Some(events) = format_events_section(&job.events, job.earlier_events_count) {
+        println!("{}", events);
+    }
 }
 
 #[cfg(test)]
@@ -198,6 +229,10 @@ mod tests {
             completed_indexes: None,
             failed_indexes: None,
             node_name: None,
+            retry_count: 0,
+            retry_after: None,
+            events: Vec::new(),
+            earlier_events_count: 0,
         }
     }
 
@@ -272,6 +307,10 @@ mod tests {
             completed_indexes: Some("0-47".to_string()),
             failed_indexes: Some("12,37".to_string()),
             node_name: Some(vec!["worker07".to_string()]),
+            retry_count: 0,
+            retry_after: None,
+            events: Vec::new(),
+            earlier_events_count: 0,
         }
     }
 
@@ -281,5 +320,62 @@ mod tests {
         let result = format_time_limit(&job);
         assert!(result.contains("6h 0m"));
         assert!(result.contains("remaining"));
+    }
+
+    #[test]
+    fn test_format_retry_lines_defaults_omitted() {
+        assert!(format_retry_lines(0, None).is_none());
+    }
+
+    #[test]
+    fn test_format_retry_lines_count_only() {
+        let out = format_retry_lines(2, None).unwrap();
+        assert!(out.contains("retry_count:   2"));
+        assert!(out.contains("retry_after:   -"));
+    }
+
+    #[test]
+    fn test_format_retry_lines_after_only() {
+        let out = format_retry_lines(0, Some("2026-04-14T12:34:56Z")).unwrap();
+        assert!(out.contains("retry_count:   0"));
+        assert!(out.contains("retry_after:   2026-04-14T12:34:56Z"));
+    }
+
+    #[test]
+    fn test_format_events_section_empty() {
+        assert!(format_events_section(&[], 0).is_none());
+    }
+
+    #[test]
+    fn test_format_events_section_no_truncation() {
+        let events = vec![
+            JobEventItem {
+                event_type: "DISPATCHED".to_string(),
+                created_at: "2026-04-14T11:17:00Z".to_string(),
+            },
+            JobEventItem {
+                event_type: "RUNNING".to_string(),
+                created_at: "2026-04-14T11:20:30Z".to_string(),
+            },
+        ];
+        let out = format_events_section(&events, 0).unwrap();
+        assert!(out.starts_with("events:"));
+        assert!(out.contains("2026-04-14T11:17:00Z  DISPATCHED"));
+        assert!(out.contains("2026-04-14T11:20:30Z  RUNNING"));
+        assert!(!out.contains("earlier events"));
+    }
+
+    #[test]
+    fn test_format_events_section_with_earlier_marker() {
+        let events = vec![JobEventItem {
+            event_type: "RUNNING".to_string(),
+            created_at: "2026-04-14T11:20:30Z".to_string(),
+        }];
+        let out = format_events_section(&events, 3).unwrap();
+        assert!(out.contains("... 3 earlier events"));
+        // Marker appears before any event entry.
+        let marker_pos = out.find("... 3 earlier events").unwrap();
+        let first_event_pos = out.find("2026-04-14T11:20:30Z").unwrap();
+        assert!(marker_pos < first_event_pos);
     }
 }

--- a/ctl/src/cmd/jobs.rs
+++ b/ctl/src/cmd/jobs.rs
@@ -146,6 +146,8 @@ pub async fn list(client: &Client, namespace: Option<&str>, status: Option<&str>
     Ok(())
 }
 
+const JOB_EVENT_DETAIL_LIMIT: i64 = 10;
+
 pub async fn status(client: &Client, namespace: &str, job_id: i32) -> Result<()> {
     let row = client
         .query_opt(
@@ -153,7 +155,8 @@ pub async fn status(client: &Client, namespace: &str, job_id: i32) -> Result<()>
                     time_limit_seconds, completions, parallelism, \
                     succeeded_count, failed_count, failed_indexes, \
                     created_at, dispatched_at, started_at, finished_at, \
-                    k8s_job_name, log_dir, last_error, node_name \
+                    k8s_job_name, log_dir, last_error, node_name, \
+                    retry_count, retry_after \
              FROM jobs \
              WHERE namespace = $1 AND job_id = $2",
             &[&namespace, &job_id],
@@ -190,6 +193,35 @@ pub async fn status(client: &Client, namespace: &str, job_id: i32) -> Result<()>
     let log_dir: Option<&str> = row.get(20);
     let last_error: Option<&str> = row.get(21);
     let node_name: Option<&str> = row.get(22);
+    let retry_count: i32 = row.get(23);
+    let retry_after: Option<chrono::DateTime<chrono::Utc>> = row.get(24);
+
+    // Fetch the most recent events (limit + 1 to detect overflow).
+    let event_rows = client
+        .query(
+            "SELECT event_type, created_at FROM job_events \
+             WHERE namespace = $1 AND job_id = $2 \
+             ORDER BY id DESC LIMIT $3",
+            &[&namespace, &job_id, &(JOB_EVENT_DETAIL_LIMIT + 1)],
+        )
+        .await?;
+    let (mut events, earlier_events_count) =
+        if event_rows.len() as i64 > JOB_EVENT_DETAIL_LIMIT {
+            let total: i64 = client
+                .query_one(
+                    "SELECT COUNT(*) FROM job_events \
+                     WHERE namespace = $1 AND job_id = $2",
+                    &[&namespace, &job_id],
+                )
+                .await?
+                .get(0);
+            let mut trimmed = event_rows;
+            trimmed.truncate(JOB_EVENT_DETAIL_LIMIT as usize);
+            (trimmed, (total - JOB_EVENT_DETAIL_LIMIT).max(0))
+        } else {
+            (event_rows, 0i64)
+        };
+    events.reverse(); // DESC -> ascending
 
     let is_sweep = completions.is_some();
     let fmt_ts = |t: Option<chrono::DateTime<chrono::Utc>>| -> String {
@@ -243,6 +275,25 @@ pub async fn status(client: &Client, namespace: &str, job_id: i32) -> Result<()>
     println!("log_dir:       {}", log_dir.unwrap_or("-"));
     if let Some(err) = last_error {
         println!("last_error:    {}", err);
+    }
+    if retry_count > 0 || retry_after.is_some() {
+        println!("retry_count:   {}", retry_count);
+        println!("retry_after:   {}", fmt_ts(retry_after));
+    }
+    if !events.is_empty() {
+        println!("events:");
+        if earlier_events_count > 0 {
+            println!("  ... {} earlier events", earlier_events_count);
+        }
+        for ev in &events {
+            let etype: &str = ev.get(0);
+            let ts: chrono::DateTime<chrono::Utc> = ev.get(1);
+            println!(
+                "  {}  {}",
+                ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                etype
+            );
+        }
     }
 
     Ok(())

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -309,11 +309,26 @@ GET /v1/jobs?time_limit_ge=21600&time_limit_lt=43200
   "failed_count": null,
   "completed_indexes": null,
   "failed_indexes": null,
-  "node_name": ["worker07", "worker08"]
+  "node_name": ["worker07", "worker08"],
+  "retry_count": 0,
+  "retry_after": null,
+  "events": [
+    {"event_type": "SUBMITTED", "created_at": "2026-03-23T12:34:56Z"},
+    {"event_type": "DISPATCHED", "created_at": "2026-03-23T12:35:02Z"},
+    {"event_type": "RUNNING",    "created_at": "2026-03-23T12:35:10Z"},
+    {"event_type": "SUCCEEDED",  "created_at": "2026-03-23T12:37:10Z"}
+  ],
+  "earlier_events_count": 0
 }
 ```
 
 `node_name` はジョブの実行に使用されたノード名のリスト（`list[str] | null`）。Watcher が RUNNING 遷移時および sweep の進行状況変化時に累積記録する。QUEUED / DISPATCHED 等の未実行ジョブでは `null`。通常ジョブでは単一要素のリスト、sweep ジョブでは使用された全ノード名のリストとなる。
+
+`retry_count` は dispatcher の K8s API 一時障害 retry 回数（[dispatcher.md](dispatcher.md) §2.4）。`retry_after` は次回 dispatch 解禁時刻（`str | null`、RFC3339）。K8s 一時障害 retry / ResourceQuota DEFERRED のどちらでも設定されうる。
+
+`events` は直近の job_events を時系列昇順（古い → 新しい）で最大 10 件返す。各要素は `event_type` と `created_at` のみを含み、`payload_json` はレスポンスには含めない。`earlier_events_count` は「レスポンスに含まれない、より古い events の件数」であり、0 の場合は切り捨てが発生していないことを意味する。ジョブに events が 1 件もない場合は `events=[]` / `earlier_events_count=0` を返す。
+
+event の canonical な種類は [database.md](database.md) §3 を参照。
 
 ### エラーレスポンス
 

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -425,6 +425,42 @@ log_dir:       /home/jovyan/.cjob/logs/5
 last_error:    K8s API permanent error 403: admission webhook "validate-image.kyverno.io" denied the request
 ```
 
+### 履歴情報（retry_count / retry_after / events）
+
+`retry_count` は dispatcher の K8s API 一時障害 retry 回数、`retry_after` は次回 dispatch 解禁時刻である。両者とも初期値の場合（`retry_count == 0` かつ `retry_after` が `null`）は行自体を表示しない。どちらかが非初期値の場合は両行を表示し、`retry_after` が `null` のときは `-` と表示する。
+
+`events` は直近の job_events を時系列昇順で最大 10 件表示する（[api.md](api.md) §4 参照）。events が 1 件もない場合はセクションごと省略する。表示可能な最大件数を超える古い events が存在する場合は、先頭に `... N earlier events` マーカーを出力する。
+
+```
+$ cjob status 7
+job_id:        7
+type:          job
+status:        RUNNING
+command:       python train.py
+cwd:           /home/jovyan/project-b
+flavor:        cpu
+cpu:           2
+memory:        4Gi
+gpu:           0
+time_limit:    6h (4h 12m remaining)
+created_at:    2026-04-14 11:16:50
+dispatched_at: 2026-04-14 11:20:25
+started_at:    2026-04-14 11:20:30
+finished_at:   -
+k8s_job_name:  cjob-alice-7
+node_name:     worker07
+log_dir:       /home/jovyan/.cjob/logs/7
+retry_count:   0
+retry_after:   -
+events:
+  2026-04-14T11:17:00Z  DISPATCHED
+  2026-04-14T11:20:15Z  DEFERRED
+  2026-04-14T11:20:25Z  DISPATCHED
+  2026-04-14T11:20:30Z  RUNNING
+```
+
+将来 `--events <N>` / `--events all` オプションで表示件数を変更できる余地を残している（現在は未実装）。`--json` 出力（未実装）は API レスポンスの `events` / `retry_count` / `retry_after` / `earlier_events_count` をそのまま返す想定である。
+
 存在しない job_id を指定した場合はエラーメッセージを表示して終了する。
 
 ```

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -90,6 +90,26 @@ CREATE TABLE job_events (
 );
 ```
 
+### 3.1 canonical `event_type` 一覧
+
+`event_type` は以下の値を canonical として扱う。新しい種別を追加する際は本節と実装を同時に更新すること。
+
+| event_type   | 記録タイミング | 記録者 | 典型的な `payload_json` |
+|---|---|---|---|
+| `SUBMITTED`  | Submit API がジョブを作成した直後 | Submit API | `{}` |
+| `DISPATCHED` | Dispatcher が K8s Job を作成し `DISPATCHING` → `DISPATCHED` に遷移した直後 | Dispatcher | `{}` |
+| `RETRY`      | Dispatcher が K8s API 一時障害で `DISPATCHING` → `QUEUED` に戻した（`retry_count` が増える） | Dispatcher | `{}` |
+| `DEFERRED`   | Dispatcher が ResourceQuota race で `DISPATCHING` → `QUEUED` に戻した（`retry_count` は増えない、[dispatcher.md](dispatcher.md) §2.5 参照） | Dispatcher | `{}` |
+| `RUNNING`    | Watcher が Pod の RUNNING 遷移を検知し DB status を `RUNNING` に更新した | Watcher | `{}` |
+| `SUCCEEDED`  | Watcher が K8s Job の complete を検知 | Watcher | `{}` |
+| `FAILED`     | Watcher / Dispatcher がジョブを FAILED に遷移させた（permanent error、retry 上限到達、K8s Job 消失など） | Dispatcher / Watcher | `{"error": "..."}`（Dispatcher の mark_failed 経由時） |
+| `CANCELLED`  | API がキャンセル要求を受理した時、または Watcher が CANCELLED ジョブを最終確定した時 | API / Watcher | `{}` |
+| `HELD`       | API が hold 操作を受理した時 | API | `{}` |
+| `RELEASED`   | API が release 操作を受理した時 | API | `{}` |
+| `SET`        | API が set 操作でパラメータを変更した時 | API | 変更内容（例: `{"cpu": "2"}`） |
+
+`GET /v1/jobs/{job_id}` レスポンスの `events` フィールドはこれらを時系列順に最大 10 件返す（[api.md](api.md) §4 参照）。CLI で表示する際も同じ文字列をそのまま表示する前提のため、新しい event_type は英大文字の短いトークンを使い、既存 event_type のリネームは避けること（CLI の後方互換を壊す）。
+
 ## 4. `namespace_weights` テーブル
 
 namespace ごとの fair sharing の重み（weight）を管理する。weight が大きい namespace ほど、同じ累計消費量でも DRF の dominant share が小さく評価され、dispatch 優先度が高くなる。

--- a/docs_en/architecture/api.md
+++ b/docs_en/architecture/api.md
@@ -311,11 +311,26 @@ Retrieve the details of an individual job.
   "failed_count": null,
   "completed_indexes": null,
   "failed_indexes": null,
-  "node_name": ["worker07", "worker08"]
+  "node_name": ["worker07", "worker08"],
+  "retry_count": 0,
+  "retry_after": null,
+  "events": [
+    {"event_type": "SUBMITTED", "created_at": "2026-03-23T12:34:56Z"},
+    {"event_type": "DISPATCHED", "created_at": "2026-03-23T12:35:02Z"},
+    {"event_type": "RUNNING",    "created_at": "2026-03-23T12:35:10Z"},
+    {"event_type": "SUCCEEDED",  "created_at": "2026-03-23T12:37:10Z"}
+  ],
+  "earlier_events_count": 0
 }
 ```
 
 `node_name` is a list of node names used for job execution (`list[str] | null`). The Watcher cumulatively records these when transitioning to RUNNING and when sweep progress changes. For unstarted jobs such as QUEUED / DISPATCHED, this is `null`. For normal jobs, it is a single-element list; for sweep jobs, it is a list of all nodes used.
+
+`retry_count` is the dispatcher's transient K8s API retry count ([dispatcher.md](dispatcher.md) §2.4). `retry_after` is the timestamp when the next dispatch attempt becomes eligible (`str | null`, RFC3339). Either a K8s transient error retry or a ResourceQuota DEFERRED event may set it.
+
+`events` returns the most recent job_events in chronological ascending order (old → new), up to 10 entries. Each element contains only `event_type` and `created_at`; `payload_json` is not included in the response. `earlier_events_count` is "the number of older events not included in the response"; a value of 0 means no truncation has occurred. If the job has no events at all, `events=[]` and `earlier_events_count=0` are returned.
+
+See [database.md](database.md) §3 for the canonical event types.
 
 ### Error Response
 

--- a/docs_en/architecture/cli.md
+++ b/docs_en/architecture/cli.md
@@ -427,6 +427,42 @@ log_dir:       /home/jovyan/.cjob/logs/5
 last_error:    K8s API permanent error 403: admission webhook "validate-image.kyverno.io" denied the request
 ```
 
+### History Information (retry_count / retry_after / events)
+
+`retry_count` is the dispatcher's transient K8s API retry count, and `retry_after` is the next dispatch eligibility timestamp. When both are at their initial values (`retry_count == 0` and `retry_after` is `null`), the lines are omitted entirely. If either is non-initial, both lines are displayed, and `-` is shown when `retry_after` is `null`.
+
+`events` displays the most recent job_events in ascending chronological order, up to 10 entries (see [api.md](api.md) §4). When there are no events at all, the section is omitted entirely. When older events beyond the display limit exist, a `... N earlier events` marker is emitted at the top of the list.
+
+```
+$ cjob status 7
+job_id:        7
+type:          job
+status:        RUNNING
+command:       python train.py
+cwd:           /home/jovyan/project-b
+flavor:        cpu
+cpu:           2
+memory:        4Gi
+gpu:           0
+time_limit:    6h (4h 12m remaining)
+created_at:    2026-04-14 11:16:50
+dispatched_at: 2026-04-14 11:20:25
+started_at:    2026-04-14 11:20:30
+finished_at:   -
+k8s_job_name:  cjob-alice-7
+node_name:     worker07
+log_dir:       /home/jovyan/.cjob/logs/7
+retry_count:   0
+retry_after:   -
+events:
+  2026-04-14T11:17:00Z  DISPATCHED
+  2026-04-14T11:20:15Z  DEFERRED
+  2026-04-14T11:20:25Z  DISPATCHED
+  2026-04-14T11:20:30Z  RUNNING
+```
+
+The design leaves room for a future `--events <N>` / `--events all` option to change the number of entries displayed (currently not implemented). When a `--json` output mode is added (not yet implemented), it is expected to surface the API response fields `events` / `retry_count` / `retry_after` / `earlier_events_count` as-is.
+
 If a nonexistent job_id is specified, an error message is displayed and the command exits.
 
 ```

--- a/docs_en/architecture/database.md
+++ b/docs_en/architecture/database.md
@@ -92,6 +92,26 @@ CREATE TABLE job_events (
 );
 ```
 
+### 3.1 Canonical `event_type` List
+
+The following values are treated as canonical for `event_type`. When adding a new kind, update this section and the implementation together.
+
+| event_type   | When recorded | Recorded by | Typical `payload_json` |
+|---|---|---|---|
+| `SUBMITTED`  | Immediately after Submit API creates the job | Submit API | `{}` |
+| `DISPATCHED` | Immediately after the Dispatcher creates the K8s Job and transitions `DISPATCHING` → `DISPATCHED` | Dispatcher | `{}` |
+| `RETRY`      | When the Dispatcher rolls `DISPATCHING` → `QUEUED` due to a transient K8s API error (`retry_count` is incremented) | Dispatcher | `{}` |
+| `DEFERRED`   | When the Dispatcher rolls `DISPATCHING` → `QUEUED` due to a ResourceQuota race (`retry_count` is left unchanged, see [dispatcher.md](dispatcher.md) §2.5) | Dispatcher | `{}` |
+| `RUNNING`    | When the Watcher detects a Pod RUNNING transition and updates the DB status to `RUNNING` | Watcher | `{}` |
+| `SUCCEEDED`  | When the Watcher detects K8s Job completion | Watcher | `{}` |
+| `FAILED`     | When the Watcher / Dispatcher transitions the job to FAILED (permanent error, retry limit exceeded, K8s Job disappeared, etc.) | Dispatcher / Watcher | `{"error": "..."}` (via Dispatcher's mark_failed) |
+| `CANCELLED`  | When the API accepts a cancel request, or when the Watcher finalizes a CANCELLED job | API / Watcher | `{}` |
+| `HELD`       | When the API accepts a hold operation | API | `{}` |
+| `RELEASED`   | When the API accepts a release operation | API | `{}` |
+| `SET`        | When the API changes parameters via a set operation | API | Change content (e.g., `{"cpu": "2"}`) |
+
+The `events` field of the `GET /v1/jobs/{job_id}` response returns these in chronological order, up to 10 entries (see [api.md](api.md) §4). Since the CLI displays the same strings as-is, new event types should use short uppercase tokens, and renaming existing event types must be avoided (it would break CLI backward compatibility).
+
 ## 4. `namespace_weights` Table
 
 Manages fair sharing weights per namespace. Namespaces with larger weights have smaller DRF dominant shares for the same cumulative consumption, resulting in higher dispatch priority.

--- a/server/src/cjob/api/schemas.py
+++ b/server/src/cjob/api/schemas.py
@@ -55,6 +55,11 @@ class JobListResponse(BaseModel):
     log_base_dir: str
 
 
+class JobEventItem(BaseModel):
+    event_type: str
+    created_at: datetime
+
+
 class JobDetailResponse(BaseModel):
     job_id: int
     status: str
@@ -80,6 +85,10 @@ class JobDetailResponse(BaseModel):
     completed_indexes: str | None = None
     failed_indexes: str | None = None
     node_name: list[str] | None = None
+    retry_count: int = 0
+    retry_after: datetime | None = None
+    events: list[JobEventItem] = Field(default_factory=list)
+    earlier_events_count: int = 0
 
 
 class SingleCancelResponse(BaseModel):

--- a/server/src/cjob/api/services.py
+++ b/server/src/cjob/api/services.py
@@ -18,6 +18,7 @@ from .schemas import (
     FlavorQuotaInfo,
     HoldResponse,
     JobDetailResponse,
+    JobEventItem,
     JobListResponse,
     JobSubmitRequest,
     JobSubmitResponse,
@@ -38,6 +39,8 @@ ACTIVE_STATUSES = {"QUEUED", "DISPATCHING", "DISPATCHED", "RUNNING", "HELD"}
 CANCELLABLE_STATUSES = {"QUEUED", "DISPATCHING", "DISPATCHED", "RUNNING", "HELD"}
 DELETABLE_STATUSES = {"SUCCEEDED", "FAILED", "CANCELLED"}
 HOLDABLE_STATUSES = {"QUEUED"}
+
+JOB_EVENT_DETAIL_LIMIT = 10
 RELEASABLE_STATUSES = {"HELD"}
 SETTABLE_STATUSES = {"QUEUED", "HELD"}
 # Statuses counted toward MAX_QUEUED_JOBS_PER_NAMESPACE
@@ -460,6 +463,35 @@ def get_job(
     if job is None:
         return None
 
+    # Fetch the most recent job_events (limit + 1 to detect overflow), then
+    # reverse so the response is ascending (old -> new) as documented in
+    # docs/architecture/api.md §4.
+    recent_rows = (
+        session.query(JobEvent)
+        .filter(JobEvent.namespace == namespace, JobEvent.job_id == job_id)
+        .order_by(JobEvent.id.desc())
+        .limit(JOB_EVENT_DETAIL_LIMIT + 1)
+        .all()
+    )
+    if len(recent_rows) > JOB_EVENT_DETAIL_LIMIT:
+        total_events = (
+            session.query(func.count(JobEvent.id))
+            .filter(
+                JobEvent.namespace == namespace,
+                JobEvent.job_id == job_id,
+            )
+            .scalar()
+            or 0
+        )
+        earlier_events_count = max(0, total_events - JOB_EVENT_DETAIL_LIMIT)
+        recent_rows = recent_rows[:JOB_EVENT_DETAIL_LIMIT]
+    else:
+        earlier_events_count = 0
+    events = [
+        JobEventItem(event_type=ev.event_type, created_at=ev.created_at)
+        for ev in reversed(recent_rows)
+    ]
+
     return JobDetailResponse(
         job_id=job.job_id,
         status=job.status,
@@ -485,6 +517,10 @@ def get_job(
         completed_indexes=job.completed_indexes,
         failed_indexes=job.failed_indexes,
         node_name=job.node_name.split(",") if job.node_name else None,
+        retry_count=job.retry_count,
+        retry_after=job.retry_after,
+        events=events,
+        earlier_events_count=earlier_events_count,
     )
 
 

--- a/server/tests/test_services.py
+++ b/server/tests/test_services.py
@@ -522,6 +522,19 @@ class TestListJobs:
 # ── get_job ──
 
 
+def _insert_job_event(session, job_id, event_type, created_at, namespace=NS):
+    """Insert a job_events row bypassing the autouse fixture that filters
+    db_session.add(JobEvent). Used by TestGetJob for events-related tests."""
+    session.execute(
+        text(
+            "INSERT INTO job_events (namespace, job_id, event_type, payload_json, created_at) "
+            "VALUES (:ns, :jid, :etype, '{}', :ts)"
+        ),
+        {"ns": namespace, "jid": job_id, "etype": event_type, "ts": created_at},
+    )
+    session.flush()
+
+
 class TestGetJob:
     def test_found(self, db_session):
         _insert_job(db_session, 1, time_limit_seconds=3600)
@@ -549,6 +562,68 @@ class TestGetJob:
         _insert_job(db_session, 1, namespace="bob", user="bob")
         resp = get_job(db_session, NS, 1)
         assert resp is None
+
+    def test_retry_fields_default(self, db_session):
+        _insert_job(db_session, 1)
+        resp = get_job(db_session, NS, 1)
+        assert resp.retry_count == 0
+        assert resp.retry_after is None
+
+    def test_retry_fields_populated(self, db_session):
+        from datetime import datetime, timezone
+        ra = datetime(2026, 4, 14, 12, 34, 56, tzinfo=timezone.utc)
+        _insert_job(db_session, 1, retry_count=2, retry_after=ra)
+        resp = get_job(db_session, NS, 1)
+        assert resp.retry_count == 2
+        assert resp.retry_after is not None
+        assert resp.retry_after.year == 2026
+
+    def test_events_empty_by_default(self, db_session):
+        _insert_job(db_session, 1)
+        resp = get_job(db_session, NS, 1)
+        assert resp.events == []
+        assert resp.earlier_events_count == 0
+
+    def test_events_returned_ascending(self, db_session):
+        _insert_job(db_session, 1)
+        _insert_job_event(db_session, 1, "SUBMITTED", "2026-04-14 11:16:50")
+        _insert_job_event(db_session, 1, "DISPATCHED", "2026-04-14 11:17:00")
+        _insert_job_event(db_session, 1, "DEFERRED", "2026-04-14 11:20:15")
+        _insert_job_event(db_session, 1, "DISPATCHED", "2026-04-14 11:20:25")
+        _insert_job_event(db_session, 1, "RUNNING", "2026-04-14 11:20:30")
+        resp = get_job(db_session, NS, 1)
+        assert [e.event_type for e in resp.events] == [
+            "SUBMITTED",
+            "DISPATCHED",
+            "DEFERRED",
+            "DISPATCHED",
+            "RUNNING",
+        ]
+        assert resp.earlier_events_count == 0
+
+    def test_events_truncated_when_over_limit(self, db_session):
+        _insert_job(db_session, 1)
+        # Insert 13 events; only the most recent 10 should be returned,
+        # and earlier_events_count should be 3.
+        for i in range(13):
+            _insert_job_event(
+                db_session, 1, f"E{i:02d}", f"2026-04-14 11:{i:02d}:00"
+            )
+        resp = get_job(db_session, NS, 1)
+        assert len(resp.events) == 10
+        assert resp.earlier_events_count == 3
+        # Ascending and the oldest of the returned set is E03 (3 earlier
+        # rows E00/E01/E02 are dropped).
+        assert resp.events[0].event_type == "E03"
+        assert resp.events[-1].event_type == "E12"
+
+    def test_events_scoped_to_job(self, db_session):
+        _insert_job(db_session, 1)
+        _insert_job(db_session, 2)
+        _insert_job_event(db_session, 1, "DISPATCHED", "2026-04-14 11:17:00")
+        _insert_job_event(db_session, 2, "SUBMITTED", "2026-04-14 11:18:00")
+        resp = get_job(db_session, NS, 1)
+        assert [e.event_type for e in resp.events] == ["DISPATCHED"]
 
 
 # ── cancel_single / cancel_bulk ──


### PR DESCRIPTION
## Summary

- Embed `retry_count`, `retry_after`, a list of the most recent `events` (up to 10, ascending), and `earlier_events_count` in the `GET /v1/jobs/{job_id}` response. Adds the `JobEventItem` schema and uses a `LIMIT+1` probe so the common (no overflow) case stays a single extra query.
- Render the new fields in `cjob status`: retry lines are emitted only when the job has a non-default retry state (matching the `last_error` policy), and an `events:` section is emitted with an optional `... N earlier events` marker. Extracted `format_retry_lines` / `format_events_section` helpers with unit tests.
- Mirror the same behavior in `cjobctl jobs status`, reading `retry_count` / `retry_after` from the `jobs` row and pulling the same 10 most recent `job_events` directly from PostgreSQL. Output format matches the user-facing `cjob status`.
- Update `docs/architecture/api.md` §4, `cli.md` §7, and `database.md` §3 (plus their English counterparts) to document the new response fields, display rules, and a canonical `event_type` catalog. Follows the design decisions locked in on issue #195.

## Test plan

- [x] `uv run python -m pytest tests/` in `server/` (413 passed, 29 skipped) — covers 6 new `TestGetJob` cases for retry/events rendering and truncation
- [x] `cargo test` in `cli/` (68 passed) — covers new unit tests for `format_retry_lines` and `format_events_section`
- [x] `cargo test` in `ctl/` (28 passed)
- [x] `cargo build` in `cli/` and `ctl/`
- [x] Integration smoke test on a real cluster: submit a job and confirm `cjob status <id>` shows the events trail, and (optionally) force a ResourceQuota DEFERRED to verify the marker appears

## Post-apply actions

- Rebuild and rollout submit-api (API response schema additively changed)
- Rebuild `cjob` and `cjobctl` binaries and distribute via `cjobctl cli deploy` / the standard CLI update path (client-side changes to render the new fields)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)